### PR TITLE
feat: add short_description for storefront tagline

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -3,6 +3,7 @@ name: Gecko
 slug: gecko
 version: 0.1.0
 description: Ecosystem intelligence — autonomous network health observation, identity-reality drift detection, and construct lifecycle monitoring. The quietest stall in the bazaar.
+short_description: "Ecosystem intelligence"
 author: 0xHoneyJar
 license: MIT
 type: skill-pack


### PR DESCRIPTION
Add `short_description` field to `construct.yaml` for constructs.network catalog display.

Tagline: **Ecosystem intelligence**

Part of 0xHoneyJar/loa-constructs#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)