### PR TITLE
chore: add composition_paths and compose_with metadata

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -81,6 +81,12 @@ paths:
   writes:
     - "grimoires/gecko/"
 
+composition_paths:
+  reads:
+    - "grimoires/"
+compose_with:
+  - observer
+  - k-hole
 pack_dependencies: []
 
 hooks:


### PR DESCRIPTION
## Summary
- Adds `composition_paths.reads: [grimoires/]` — gecko reads ALL grimoires for ecosystem-wide health monitoring
- Adds `compose_with: [observer, k-hole]` — gecko correlates observer signals and k-hole research emergence

## Why
Part of the ecosystem-wide composition metadata fan-out. Gecko is the ecosystem intelligence construct — it already has `paths` (construct-repo file reads) and `paths.writes: [grimoires/gecko/]`. The new `composition_paths` field describes network-level grimoire I/O, distinct from the skill-level `paths` field. Gecko's broad grimoire read access is necessary for cross-construct health correlation.

## Test plan
- [ ] `yq eval '.' construct.yaml` parses without error
- [ ] Fields are additive only — no existing fields modified
- [ ] `composition_paths` is distinct from existing `paths` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)