### PR TITLE
feat: add capability metadata for runtime routing

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -89,6 +89,17 @@ compose_with:
   - k-hole
 pack_dependencies: []
 
+capabilities:
+  model_tier: opus
+  danger_level: moderate
+  effort_hint: large
+  downgrade_allowed: false
+  execution_hint: sequential
+  requires:
+    tool_calling: true
+    thinking_traces: true
+    vision: false
+
 hooks:
   post_install: scripts/install.sh
 


### PR DESCRIPTION
## Summary
- Add capabilities stanza for runtime model routing

## Changes
- `construct.yaml`: capabilities metadata added (model_tier: opus, danger_level: moderate, effort_hint: large)

## Context
Network audit (2026-03-17) found 21/22 constructs had no capability metadata.
Only vocabulary-bank had a partial stanza. This blocks runtime routing.