### PR TITLE
chore(skills): add allowed-tools + user-invocable frontmatter per ecosystem-health cycle 001 (TEND)

### DIFF
--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: diagnose
+description: "Deep investigation of a single construct. Identity-reality drift, maintenance pattern, composition analysis."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
 # Diagnose — Deep Construct Investigation
 
 ## Purpose

--- a/skills/observe/SKILL.md
+++ b/skills/observe/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: observe
+description: "Single-pass network health observation. Checks API liveness, namespace freshness, drift, computes Network Health Score."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
 # Observe — Single-Pass Network Health Check
 
 ## Purpose

--- a/skills/patrol/SKILL.md
+++ b/skills/patrol/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: patrol
+description: "Autonomous observation loop. Time-boxed cycles with ratcheting health score, commits findings to grimoires."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
 # Patrol — Autonomous Observation Loop
 
 ## Purpose

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: report
+description: "Synthesize observations into a readable network health report. Aggregates patterns and trends from observation cycles."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
 # Report — Network Health Synthesis
 
 ## Purpose


### PR DESCRIPTION
## Summary
- Adds canonical frontmatter (`name` / `description` / `allowed-tools` / `user-invocable: true`) to all 4 skills: `diagnose`, `observe`, `patrol`, `report`
- All 4 skills are slash-command surfaces (`/diagnose`, `/observe`, `/patrol`, `/report`) — `user-invocable: true`
- `allowed-tools` permissive baseline `[Bash, Read, Grep, Glob, Write, Edit]` covering the GitHub API + grimoire-write workflow these skills run

## Why
Lane B2 of TEND cycle 001 phase 3 fix wave — `construct-gecko` was at 0% frontmatter compliance per `~/vault/wiki/observations/ecosystem-health-2026-05-02.md` pattern 2.

Doctrine refs (read-only):
- `~/vault/wiki/observations/ecosystem-health-2026-05-02.md` (pattern 2)
- `~/bonfire/grimoires/loa/observations/keeper-triage-2026-05-02.md` §1.④

## Scope discipline
- Only `skills/*/SKILL.md` frontmatter touched
- Persona narrative under `identity/` deliberately untouched (deferred per §3.a doctrine question)
- No content / methodology changes

## Test plan
- [ ] Visual diff: each SKILL.md gains a frontmatter block at the top, body content unchanged
- [ ] `name` matches directory name
- [ ] `user-invocable: true` set for all four (slash-command surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)