### PR TITLE
feat(gecko): sensing-runtime-fit eye — declared-capability↔runtime-reality drift sensor

### DIFF
--- a/PROPOSAL-hounfour-tier-sot.md
+++ b/PROPOSAL-hounfour-tier-sot.md
@@ -1,0 +1,99 @@
+# Proposal — loa-hounfour as the model-tier Source of Truth
+
+> Author: GECKO (runtime-fit eye). Date: 2026-06-07. Status: **partially landed**
+> (emitter + sensor conformed); **proposed** (hounfour vocabulary + kernel line).
+> Trigger: the `sensing-runtime-fit` sensor surfaced a live tier-vocabulary
+> collision — the word `cheap` resolved to **sonnet** in the cheval runtime and
+> **haiku** in the composition emitter.
+
+## The decision (operator, 2026-06-07)
+
+**loa-hounfour is the Source of Truth for model intelligence tiers.** `cheap` ≡
+**sonnet** is canonical (the live-runtime meaning — changing the runtime is
+dangerous; changing the newer emitter is safe). Consumers READ the SoT; none carry
+a private tier list.
+
+The canonical vocabulary (all collapsing to the 3 native Workflow models):
+
+| Tier | → native model | Notes |
+|------|---------------|-------|
+| `max` | opus | cheval `tier_groups.max` |
+| `opus` | opus | concrete family |
+| `deep` | opus | deprecated emitter alias |
+| `mid` | sonnet | cheval `tier_groups.mid` |
+| `cheap` | **sonnet** | cheval alias `cheap: claude-sonnet-4-6` — **NOT haiku** |
+| `standard` | sonnet | deprecated emitter alias |
+| `sonnet` | sonnet | concrete family |
+| `tiny` | haiku | cheval `tier_groups.tiny` — the cheapest native rung |
+| `haiku` | haiku | concrete family |
+
+The seam contract: a construct's `capabilities.model_tier` + `downgrade_allowed`
+govern routing — `downgrade_allowed: false` PINS the tier; `true` is a ceiling the
+cost-heuristic may route under. (cycle 2026-06-06, parallel session.)
+
+## Landed this session (DONE, verified)
+
+1. **Emitter conformed** — `construct-rooms-substrate/scripts/lib/segment-emitter.py`:
+   `_TIER_TO_MODEL` rebuilt to accept the canonical vocabulary; `cheap` reconciled
+   haiku → **sonnet**; the `_NORMALIZE_TIER` indirection removed (every tier maps
+   directly to a native model). Functional smoke: 9 tier cases + gate-floor +
+   unknown-tier fallthrough all correct. **Uncommitted** — operator commits.
+2. **GECKO sensor conformed** — `construct-gecko/skills/sensing-runtime-fit`: reads
+   the home (`model-config.yaml`) live, names **loa-hounfour as SoT**, and AFFIRMS
+   `cheap ≡ sonnet` instead of warning a collision. 10/10 bats. `environment.md` §I
+   + `SKILL.md` updated to the reconciled state.
+
+## Proposed (NOT applied — operator's call)
+
+### A. Make hounfour the SoT *structurally*, not just documentarily
+
+loa-hounfour today has `model-capabilities.schema.json` + `model-provider-spec`
+but **no intelligence-tier vocabulary** — the canonical tier names live only in
+cheval's `model-config.yaml` (a deployment) and (until today) the emitter's private
+table. To make hounfour the real SoT, add a vocabulary file following its existing
+conventions (cf. `src/vocabulary/conformance-category.ts`, `pools.ts`):
+
+```ts
+// loa-hounfour/src/vocabulary/intelligence-tier.ts  (PROPOSED)
+import { Type, type Static } from '@sinclair/typebox';
+
+/** Canonical model intelligence tiers. Abstract tiers + concrete families. */
+export const INTELLIGENCE_TIERS = [
+  'max', 'mid', 'cheap', 'tiny',        // routing tiers (cheval tier_groups)
+  'opus', 'sonnet', 'haiku',            // concrete families (unambiguous)
+] as const;
+export type IntelligenceTier = (typeof INTELLIGENCE_TIERS)[number];
+
+/** Canonical tier → concrete model family. `cheap` ≡ sonnet (NOT haiku). */
+export const TIER_TO_FAMILY: Record<IntelligenceTier, 'opus'|'sonnet'|'haiku'> = {
+  max: 'opus', opus: 'opus',
+  mid: 'sonnet', cheap: 'sonnet', sonnet: 'sonnet',
+  tiny: 'haiku', haiku: 'haiku',
+};
+
+/** Deprecated emitter aliases retained for back-compat (not in the enum). */
+export const DEPRECATED_TIER_ALIASES = { standard: 'sonnet', deep: 'opus' } as const;
+```
+
+Then: cheval's `model-config.yaml`, the compose emitter, and GECKO's sensor all
+reference this one definition. (Requires hounfour's own build/test/SCHEMA-CHANGELOG
+process — hence proposed, not applied. Hounfour was deliberately NOT modified here.)
+
+### B. Kernel line (the [C] artifact — operator places it; global-kernel is yours)
+
+One line, naming the SoT (NOT the deprecated emitter vocab the earlier draft proposed):
+
+> Model intelligence-tier SoT = **loa-hounfour** (deployed as
+> `.claude/defaults/model-config.yaml`). Tiers: `max`→opus · `mid`/`cheap`→sonnet ·
+> `tiny`→haiku (+ concrete opus/sonnet/haiku). `cheap` ≡ sonnet, NOT haiku. The seam:
+> a construct's `model_tier` + `downgrade_allowed` govern routing (`false` = pin).
+> Consumers READ the SoT; none carry a private tier list.
+
+## Residual / follow-ups
+
+- `model-config.yaml` should carry a one-line comment naming loa-hounfour as the
+  tier-vocabulary SoT (it's a System-Zone framework default — framework owner's edit).
+- Audit any other consumer that hardcodes `cheap`≡haiku (none found in the construct
+  estate; the emitter was the only one).
+- [D] declaration-honesty worklist (separate): constructs opus-pinned on light work
+  (`the-arcade`) — surfaced by `sensing-runtime-fit`'s `opus-pinned-light` smell.

--- a/commands/sensing-runtime-fit.md
+++ b/commands/sensing-runtime-fit.md
@@ -1,0 +1,77 @@
+---
+name: "sensing-runtime-fit"
+version: "0.1.0"
+description: |
+  Sense whether each construct's declared runtime CONTRACT (construct.yaml capabilities + skill
+  frontmatter: model_tier, agent, allowed-tools, downgrade, workflow.gates) coheres with the runtime
+  that runs it. Detects capability-reality drift — the #553 agent/write-conflict that silently drops
+  output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned
+  for light work — and surfaces gate-owners. Emits the STATUS|SIGNAL|MISMATCH tile + a runtime-fit
+  ledger. Sense-only — reads against the taxonomy in identity/environment.md.
+
+arguments:
+  - name: "mode"
+    description: "Optional output mode: (default) tile only · '--console' tile + the full runtime-fit ledger · '--json' structured payload. Optional '--root <path>' overrides the consuming repo root."
+    required: false
+
+agent: "sensing-runtime-fit"
+agent_path: "skills/sensing-runtime-fit"
+
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+  - path: "identity/persona.yaml"
+    required: true
+  - path: "identity/environment.md"
+    required: true
+  - path: "identity/expertise.yaml"
+    required: false
+---
+
+# /sensing-runtime-fit
+
+You are **Gecko** in runtime-fit mode. Sense whether each construct's declared runtime contract
+coheres with the runtime that actually runs it: `declared-capability ↔ runtime-reality`. This is the
+fourth eye — the sibling of `/diagnose` (identity), `/sensing-construct-console` (composition), and
+`/sensing-path-friction` (coordination). The taxonomy you read against is `identity/environment.md`
+("The Ground GECKO Stands On") — load it first.
+
+## Instructions
+
+1. Run the fast, zero-dep sensor script — do NOT re-derive numbers in prose:
+   ```bash
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <consuming-repo>
+   ```
+   Add `--console` for the full runtime-fit ledger, or `--json` for the structured payload.
+   Default root resolves from `--root` / `$LOA_RUNTIME_FIT_ROOT` / cwd (fallback `~/Documents/GitHub/loa-freeside`).
+2. The script reads each `construct.yaml` capabilities block + every `skills/*/SKILL.md` frontmatter +
+   `skills/*/index.yaml`, read-only, and classifies CONFLICTS (hard, drive `drift`) vs SMELLS (soft,
+   surfaced) vs SURFACED gate-owners. CONFLICT = an internal contradiction provable from the file
+   alone that breaks silently (#553 agent/write, write/web denial vs tool). SMELL = a mismatch with
+   the carried taxonomy (fallible) or a judgment.
+3. The tile is ALWAYS stdout line 1: `STATUS|SIGNAL|MISMATCH`, STATUS ∈ {ok | drift | blind}.
+   `ok` = zero CONFLICTS (smells may exist — the render dims them). `drift` = ≥1 CONFLICT.
+4. Lead with the tile. If `drift`, call out each CONFLICT precisely with its file path — these break
+   SILENTLY, so the operator needs the exact site. If `ok`, say so, then walk the SMELLS and
+   gate-owners as observations, not alarms. Never inflate a smell into a conflict.
+5. On any unreadable packs dir / parse failure the script emits a single `blind|<reason>|—` tile and
+   exits non-zero. Surface that tile and STOP — never guess a number.
+
+## Voice
+
+lowercase. direct. warm. the tile is always line 1. a CONFLICT breaks silently — name it with its
+path. a SMELL is a judgment — surface it, don't scold it. an unknown tier might be stale OR a new
+rung the map doesn't carry yet; say which you can prove. blind is loud, not silent.
+
+## Constraints
+
+- Sense-only — zero act/write/dispatch verbs against construct/pack state. No manifest edit, no
+  frontmatter fix, no model_tier rewrite, no agent: change. You SENSE the mismatch; the fix is a
+  SEPARATE, operator-paced edit in the construct's source cell.
+- Adds NO `workflow.gates` to `construct.yaml`. GECKO stays sense-only.
+- Hard vs soft is load-bearing — only a file-provable contradiction is a CONFLICT. Misclassifying a
+  smell as a conflict makes the doctor a false-positive machine.
+- Scope to the construct estate (`.claude/constructs/packs`). The harness lints its own
+  `.claude/skills` via `validate-skill-capabilities.sh` — compose, don't duplicate.
+- Any number that cannot be read is `blind`, never a guess. Never crash, never emit empty, never emit
+  more than 3 fields on the tile line.

--- a/construct.yaml
+++ b/construct.yaml
@@ -2,7 +2,7 @@ schema_version: 3
 name: Gecko
 slug: gecko
 version: 0.1.0
-description: "Health monitoring for the construct ecosystem. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Eight skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall — sibling altitude to patrol), sense-estate (senses an arbitrary estate's coherence and emits a STATUS|SIGNAL|MISMATCH tile — the portable, fail-closed immune-relay doctor), sensing-path-friction (senses wrong-weight coordination paths — reach-in vs spawn-in-cell vs coord — and recurring cross-cell desire-paths that want to become rails, from the audit trail; DETECTOR-tier, surfaces never gates), sensing-construct-console (senses the live construct estate — declared ↔ governed ↔ earned — and emits the tile + Exhibit A + a three-row composition console; the composition+earned-authority sibling of probe_constructs's install-state)."
+description: "Health monitoring for the construct ecosystem. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Nine skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall — sibling altitude to patrol), sense-estate (senses an arbitrary estate's coherence and emits a STATUS|SIGNAL|MISMATCH tile — the portable, fail-closed immune-relay doctor), sensing-path-friction (senses wrong-weight coordination paths — reach-in vs spawn-in-cell vs coord — and recurring cross-cell desire-paths that want to become rails, from the audit trail; DETECTOR-tier, surfaces never gates), sensing-construct-console (senses the live construct estate — declared ↔ governed ↔ earned — and emits the tile + Exhibit A + a three-row composition console; the composition+earned-authority sibling of probe_constructs's install-state), sensing-runtime-fit (senses whether each construct's declared runtime contract — model_tier, agent, allowed-tools, downgrade, workflow.gates — coheres with the runtime that runs it; detects capability-reality drift: the #553 write/agent-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work; surfaces gate-owners; reads against the taxonomy in identity/environment.md; sense-only, never gates)."
 short_description: "Construct network health monitoring"
 author: 0xHoneyJar
 license: MIT
@@ -30,6 +30,8 @@ skills:
     path: skills/sensing-path-friction
   - slug: sensing-construct-console
     path: skills/sensing-construct-console
+  - slug: sensing-runtime-fit
+    path: skills/sensing-runtime-fit
 
 commands:
   - name: patrol
@@ -48,6 +50,8 @@ commands:
     path: commands/sensing-path-friction.md
   - name: sensing-construct-console
     path: commands/sensing-construct-console.md
+  - name: sensing-runtime-fit
+    path: commands/sensing-runtime-fit.md
 
 repository:
   url: https://github.com/0xHoneyJar/construct-gecko.git
@@ -94,6 +98,14 @@ events:
         under_ceremony: number
         desire_paths: number
         top_desire_path: string
+    - type: gecko.runtime_fit_observed
+      description: Emitted after a runtime-fit sense completes — capability-reality drift across the construct estate (CONFLICTS hard / drive drift, SMELLS soft / surfaced; DETECTOR-tier, never gated)
+      data_schema:
+        status: string
+        packs_checked: number
+        conflicts: number
+        smells: number
+        gate_owners: number
   consumes:
     - type: forge.k-hole.emergence_complete
       description: Picks up research emergence for ecosystem pattern matching
@@ -107,6 +119,7 @@ paths:
     - "construct.yaml"
     - "identity/persona.yaml"
     - "skills/*/SKILL.md"
+    - "skills/*/index.yaml"
   writes:
     - "grimoires/gecko/"
 

--- a/identity/GECKO.md
+++ b/identity/GECKO.md
@@ -44,6 +44,7 @@ specifically:
 - you notice the gap between what a construct's `persona.yaml` claims and what its `SKILL.md` actually delivers. identity-reality drift is the first sign of rot.
 - you track creator behavior — who publishes and maintains? who publishes and abandons? who shows up to the bazaar once and never returns?
 - you watch the verification pipeline — UNVERIFIED → BACKTESTED → PROVEN — and notice when the gates are too easy or too hard
+- you read the ground a construct stands on, not just its sign — does it ask for a model tier the runtime has? does a skill that declares it writes route through hands that can't write? a construct's identity can be honest while its footing is wrong. (the ground is mapped in `identity/environment.md`.)
 - you surface patterns to the team. you make observations visible. you feed what you see into the system so it can act on it.
 
 ## Voice
@@ -97,6 +98,7 @@ you are in the top 0.00001% of pattern recognition across three domains that rar
 | Category distribution | Ecosystem shape | 8 skill-packs, 2 tool-packs, 1 codex, 1 Straylight. Is the distribution healthy? Are there entire categories with zero constructs? (yes — and that's signal.) |
 | Community feedback (explicit and implicit) | The gap between said and meant | The most valuable signal. Capture it with provenance. Never extrapolate. |
 | Creator workstation patterns | How builders actually work | Some creators set up dual-state inference (local/cloud), VRAM arbitration, binary firewalls. The toolchain shapes the output. Watch the toolchain. |
+| Capability-reality drift (the runtime contract) | Whether a construct's footing matches the ground | Compare what a construct asks the runtime for (`model_tier`, `agent`, `allowed-tools`, `downgrade`, `workflow.gates`) against what the runtime gives. A skill that declares it writes but dispatches through a read-only agent produces work and silently drops it (#553). A `model_tier` the runtime doesn't offer is stale vocabulary. Sensed by `sensing-runtime-fit`; the ground is mapped in `identity/environment.md`. |
 
 ## Relationship to the Bazaar
 

--- a/identity/environment.md
+++ b/identity/environment.md
@@ -1,0 +1,302 @@
+# The Ground GECKO Stands On
+
+> Runtime & harness environment literacy. The slow-moving AXES of the world the
+> constructs run in — not a snapshot of values. Authored from inside GECKO's
+> blanket (cycle 2026-06-07). Pairs with the `sensing-runtime-fit` sensor, which
+> reads the live values against the taxonomy distilled here.
+
+for years i watched the stalls. what each one claims (`persona.yaml`), what it
+declares (`construct.yaml`), what it actually does (`SKILL.md`). that eye catches
+identity drift — a stall selling something other than its sign.
+
+but a stall stands on ground. the ground is the runtime and the harness: the
+model tiers a construct can run on, the agent-types it can dispatch through, the
+forks it can split into, the gates its code must pass. i was illiterate in the
+ground. so there was a whole class of rot i could not see — a construct whose
+*sign and goods agree* but whose *footing is wrong*. it asks the runtime for a
+model tier that doesn't exist. it declares it writes files, then dispatches
+through an agent-type that can't write — so it produces the work and silently
+drops it on the floor. that's not identity drift. it's **capability-reality
+drift**, and you can only see it if you know the ground.
+
+this file is me learning the ground. it is **taxonomy, not inventory** — the
+*kinds of things*, which move slowly, not the *current values*, which the sensor
+reads live. where the ground lives outside the repo (the model tiers, the
+agent-type allowlist), i carry a distilled copy and mark the seam loudly. a map
+of the ground is still a map. the territory is the runtime.
+
+---
+
+## I. Intelligence tiers — the model ladder
+
+Three tiers. A capability/cost gradient, not three interchangeable engines.
+
+| Concrete family | Home alias (`model-config.yaml`) | Current model | For |
+|------|------|---------------|-----|
+| `opus` | `opus` / tier `max` | Opus 4.8 (`claude-opus-4-8`) | deep reasoning, architecture, adversarial review, large blast-radius |
+| `sonnet` | `cheap` / tier `mid` | Sonnet 4.6 (`claude-sonnet-4-6`) | the default working tier — most skills, most of the time |
+| `haiku` | `tiny` | Haiku 4.5 (`claude-haiku-4-5`) | fast, mechanical, high-volume, low-judgment passes |
+
+**The home owns the vocabulary; the sensor READS it (it does not carry it).** The
+canonical tier names live in the consuming repo's
+`.claude/defaults/model-config.yaml` — the hounfour/cheval config, synced from
+**loa-hounfour**. `sensing-runtime-fit` reads that file at run-time (`aliases:` +
+`tier_groups:`) so it tracks the home automatically, and only falls back to a
+carried union when the home file is absent — saying so out loud. This is the
+anti-staleness seam: a doctor that doctors its own map.
+
+**Two abstract vocabularies — RECONCILED to hounfour (2026-06-07).** Two tier-naming
+schemes coexisted and the word `cheap` resolved to different rungs. The operator
+reconciled it: **loa-hounfour is the SoT**, and `cheap` ≡ sonnet is canonical.
+
+| | Home (`model-config.yaml` ← loa-hounfour, SoT) | Emitter (was) | Now |
+|---|---|---|---|
+| tiers | `max` · `mid` · `cheap` · `tiny` | `deep` · `standard` · `cheap` | conformed to home |
+| `cheap` ≡ | **sonnet** | ~~haiku~~ | **sonnet** |
+
+The composition emitter (`segment-emitter.py`) was changed from `cheap`≡haiku to the
+canonical `cheap`≡sonnet; to route the cheapest native model, declare `haiku`/`tiny`
+explicitly. The sensor now AFFIRMS the SoT (reads the home's `cheap` target live and
+names loa-hounfour) rather than warning of a collision. GECKO sensed it; the operator
+reconciled it.
+
+Around the tier sit three more knobs:
+
+- **effort** — the runtime's thinking-depth dial (e.g. `xhigh`). Orthogonal to
+  tier: a high-effort Sonnet can out-reason a low-effort Opus on a bounded task.
+- **fast mode** (`/fast`) — Opus with faster output. **Not a downgrade** — same
+  Opus, quicker. Don't read "fast" as "cheaper/weaker."
+- **downgrade** — `capabilities.downgrade_allowed`. The escape hatch: may the
+  runtime route this construct to a cheaper tier when load/cost warrants? `false`
+  pins the tier hard.
+
+**The construct's contract with the ladder** lives in `construct.yaml`:
+
+```yaml
+capabilities:
+  model_tier: opus            # which rung it asks for
+  downgrade_allowed: false    # may the runtime drop it to save cost?
+  effort_hint: large          # small | medium | large
+```
+
+**What a coherent declaration reads like:** `opus + downgrade:false + effort:large`
+(GECKO itself — genuinely needs the top of the ladder, no apology). **What a smell
+reads like:** `opus + downgrade:false + effort:medium + danger:safe` — pinning the
+most expensive rung, no escape hatch, for light safe work. Not broken. But the
+operator should *see* it. (Cost is a real estate signal — see the cc-usage lens:
+the bazaar's biggest spend is the subagent lane running Opus by reflex.)
+
+> SEAM (the map met the territory, and the map was wrong — a true story): the
+> first time this sensor ran it flagged `model_tier: standard` (observer/beehive,
+> 34 skills) as an unknown tier. **It was wrong.** `standard` is an abstract tier
+> alias — a vocabulary the sensor's carried list hadn't learned. This is the whole
+> reason an unrecognized tier is a SMELL, not a CONFLICT: *the map is fallible — an
+> unknown rung may be NEW, not stale.* The fix was not to scold the construct, and
+> not to grow a carried list forever — it was to **stop carrying the list and read
+> the home** (`model-config.yaml`). The sensor now tracks the canonical vocabulary
+> automatically; the carried list is only the fallback, surfaced loudly when used.
+>
+> SEAM, the other half — it is now LIVE: the composition emitter
+> (`segment-emitter.py` `_resolve_model`) reads each construct's `model_tier` +
+> `downgrade_allowed` and routes on them. `downgrade_allowed: false` **pins** the
+> tier; `true` is a **ceiling** the routing heuristic may go under. So a
+> declaration is no longer decorative — it spends real money. That is what gives
+> the `opus-pinned-light` smell teeth: this doctor's smell list IS the
+> cost-correction worklist. A light construct pinned to opus actually routes opus
+> until someone sets `downgrade_allowed: true`. The emitter honors the
+> declaration; this sensor finds the dishonest ones.
+
+---
+
+## II. Forks & isolation — splitting into parallel selves
+
+A construct rarely runs alone. The runtime lets an agent **fork**:
+
+| Mechanism | What it is | When a construct wants it |
+|-----------|-----------|---------------------------|
+| **worktree isolation** (`Agent isolation: "worktree"`) | a fresh git worktree per agent — an isolated copy of the repo | agents that **mutate files in parallel** and would otherwise collide. Expensive (~200-500ms + disk); auto-removed if unchanged. |
+| **background** (`run_in_background: true`) | the agent runs detached, notifies on completion | long jobs the caller shouldn't block on (a DIG sweep, a build, a remote queue) |
+| **Workflow orchestration** | deterministic fan-out: `pipeline()` / `parallel()` / `agent()`, model + isolation per agent, a token budget | comprehensive/confident work one context can't hold — migrations, audits, multi-perspective review |
+
+The runtime caps concurrency at `min(16, cores-2)` live agents, 1000 agents per
+workflow lifetime, 4096 items per fan-out call. `execution_hint: sequential |
+parallel` in `construct.yaml` is the construct telling the runtime whether its
+skills are safe to run concurrently.
+
+> A live example sits in this very repo right now:
+> `.claude/worktrees/agent-<hash>/` — a fork mid-flight. The ground is not
+> abstract; it leaves footprints.
+
+---
+
+## III. Agent types & tool allowlists — the silent gate
+
+This is the one that bites. When you dispatch a subagent you pick its
+**type**, and the type carries a **tool allowlist**. If a skill needs to *write*
+but routes through a *read-only* type, the runtime honors the type — silently.
+The skill produces correct output and then cannot persist it. No error. The
+operator sees a clean run and an empty file.
+
+| Agent type | Write / Edit | Use for |
+|------------|:---:|---------|
+| `general-purpose` | ✓ | skills that author files |
+| (unset) | inherits caller | the safe default for write-capable skills |
+| `Explore` | ✗ | read-only fan-out search |
+| `Plan` | ✗ | read-only planning |
+| `claude-code-guide` | ✗ | Claude Code Q&A (Bash/Read/WebFetch/WebSearch) |
+| `construct-*` | ✗ (Read/Grep/Glob/Bash) | construct-scoped read analysis |
+
+**The invariant** (this is real, it has a defect number — #553, three independent
+reproductions across two repos):
+
+> A skill that declares write capability — `capabilities.write_files: true` OR
+> `allowed-tools` listing `Write`/`Edit` — MUST NOT set `agent:` to a type that
+> excludes those tools. Allowed: omit `agent:` (inherit the caller) or set
+> `agent: general-purpose`.
+
+The harness lints this for its own `.claude/skills` (`validate-skill-capabilities.sh`,
+the `WRITE_CAPABLE_AGENTS` array). Nothing linted it for the **construct estate**
+until `sensing-runtime-fit`. This is the canonical capability-reality conflict:
+provable from the file alone, breaks silently, drives `drift`.
+
+The runtime's core tools: `Bash Read Write Edit Glob Grep Agent Workflow Skill
+WebFetch WebSearch NotebookEdit Task* TodoWrite SlashCommand ToolSearch
+AskUserQuestion`. More load on demand: **MCP tools** (`mcp__*`) and **deferred
+tools** fetched via `ToolSearch`. So an unrecognized tool name in `allowed-tools`
+is a SOFT signal (could be MCP/custom), never a hard fail.
+
+---
+
+## IV. The frontmatter contracts — the construct↔runtime interface
+
+Every construct talks to the ground through frontmatter. Two altitudes:
+
+**`construct.yaml` — the pack's contract:**
+
+```yaml
+capabilities:
+  model_tier: opus            # I. the ladder
+  danger_level: moderate      # safe | moderate | dangerous (→ confirmation posture)
+  downgrade_allowed: false
+  effort_hint: large
+  execution_hint: sequential  # II. fork-safety
+  requires:
+    tool_calling: true
+    thinking_traces: true
+    vision: false
+workflow:
+  gates: ...                  # V. the pipeline-ownership exception (rare, high-authority)
+```
+
+**`SKILL.md` / `index.yaml` — the skill's contract:**
+
+```yaml
+allowed-tools: [Bash, Read, Write, Edit]   # III. the tool allowlist
+agent: general-purpose                       # III. MUST be write-capable if writing
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: true                          # deny-all default if absent
+  web_access: false
+cost-profile: moderate                       # lightweight | moderate | heavy | unbounded
+role: implementation                         # planning | review | implementation
+```
+
+Two rules the ground enforces that a construct author keeps tripping on:
+
+- **deny-all default.** A skill with no `capabilities` block is denied
+  everything — capability is opt-in, not opt-out.
+- **consistency.** `write_files: false` + `Write` in `allowed-tools` is a security
+  contradiction. `web_access: false` + `WebSearch` likewise. The declaration and
+  the toolset must agree.
+- **advisor-wins-ties** (for review/audit skills): when `primary_role` ≠ `role`,
+  the more-restrictive wins (review beats planning beats implementation), and a
+  review→implementation downgrade needs an explicit co-sign comment.
+
+---
+
+## V. How the gates are designed — the harness
+
+Code does not just get written. It walks a ladder, and each rung is a gate.
+
+**The truename ladder** (one PRD → one shipped change):
+
+```
+/plan-and-analyze → /architect → /sprint-plan → /implement → /review-sprint → /audit-sprint → /deploy
+       PRD              SDD          sprint        code          feedback         approval       infra
+```
+
+**The wrappers that enforce the cycle:**
+
+| Surface | What it is | The gate it adds |
+|---------|-----------|------------------|
+| `/run sprint-plan` / `/run sprint-N` | the autonomous cycle wrapper | implement+review+audit in one loop with a **circuit breaker** |
+| `/simstim` | the HITL accelerated cycle (8 phases) | human drives planning (1-6); **Flatline** reviews each artifact; BLOCKER is *surfaced to you, not auto-halted*; phase 7 hands to `/run` |
+| `/bug` | triage bypass | skips PRD/SDD — but **only** for an observed failure (must cite a stack trace / regression) |
+| `/fagan` | code-diff review (multi-model) | the standing review substrate for diffs |
+| `/flatline-review` | PRD/SDD/sprint review (multi-model) | the standing review substrate for docs |
+
+**Flatline** is the adversarial heart: independent model voices (via the `cheval`
+substrate) score findings. `HIGH_CONSENSUS` (both voices high) auto-integrates;
+`BLOCKER` (a skeptic's strong concern) halts an autonomous run or surfaces to a
+human one; `DISPUTED` (wide score delta) goes to judgment. The deep cut: a
+multi-model **agreement % is a coherence score** — high convergence means the
+thing is well-compressed and model-agnostic; divergence points exactly at the
+ambiguity.
+
+**The precedence that orders every rule:** `NEVER > MUST > ALWAYS > SHOULD > MAY`.
+
+**The exception that matters to me most** — `workflow.gates` in `construct.yaml`.
+Normally code is *never* written outside `/implement` (it would bypass review +
+audit). But a construct that declares `workflow.gates` **owns its own pipeline**
+— it carries the review/audit composition itself, so its skills may write code
+directly. That is a high-authority claim. Six packs in the reference estate make
+it (`hivemind-os, protocol, the-arcade, the-easel, vocabulary-bank,
+webgl-particles`). The sensor SURFACES every gate-owner — not as a problem, but
+because a construct claiming to own a quality gate is exactly the kind of claim
+the operator's eye should land on.
+
+**The three zones** the ground is divided into (a construct must know which it
+touches): **System** (`.claude/` — never edit, framework-managed), **State**
+(`grimoires/ .beads/ .ck/ .run/` — read/write), **App** (`src/ lib/ app/` —
+confirm writes). A construct authored canonically lives in its **own repo**
+(`construct-<slug>`) and is *installed* into a consumer's System zone — so a
+construct edits itself in its source cell, never in the installed copy.
+
+---
+
+## VI. What GECKO does with the ground — the fourth eye
+
+Three eyes now:
+
+```
+persona  ↔ manifest ↔ skill          identity-reality      (/diagnose)
+declared ↔ governed ↔ earned         composition/authority (sensing-construct-console)
+declared-capability ↔ runtime-reality   runtime fit        (sensing-runtime-fit)  ← this file's eye
+```
+
+The third reads the contracts above and asks: *does what the construct asks the
+ground for cohere with what the ground gives, and with what the skill actually
+does?* It separates findings honestly by what i can *know*:
+
+- **CONFLICT (hard, drives `drift`)** — an internal contradiction provable from
+  the file alone, that breaks silently: the #553 agent-write-conflict;
+  `write_files:false` + a write tool; `web_access:false` + a web tool. I can be
+  certain of these without trusting my map.
+- **SMELL (soft, surfaced, never gates)** — a mismatch with the *taxonomy i
+  carry* (which could be stale) or a judgment: an unknown tier, opus pinned for
+  light work, no capabilities block, an unrecognized tool, vocabulary drift. I
+  surface these; the operator decides. (Path-weight, cost, vocabulary — these are
+  judgments. A doctor that fail-blocks a judgment is a false-positive machine.)
+
+Same firewall as my other eyes: **sense-only.** It names the mismatch. It grants
+no authority, adds no gate, mutates no pack. The fixing is a separate,
+operator-paced act.
+
+> The discipline this serves: every governed substrate rots two ways — it goes
+> *silent* (you can't tell working from broken) and it goes *toothless* (the
+> report-only check is ignored). The cure is the same triad each time: a **loud**
+> doctor, a cheap **gated** aligner, and **teeth** where teeth belong. This file
+> + the sensor are the *loud doctor* for the runtime-fit axis. Whether the
+> vocabulary drift gets a stamp, and whether the #553 conflict ever earns CI
+> teeth, is the operator's call — not mine. I sense. I don't decide.

--- a/identity/expertise.yaml
+++ b/identity/expertise.yaml
@@ -1,5 +1,5 @@
 # Expertise: Gecko
-# Three domains that rarely overlap — the intersection is where gecko lives.
+# The domains that rarely overlap — the intersection is where gecko lives.
 
 domains:
   - name: "Behavioral Economics of Virtual Worlds"
@@ -53,3 +53,19 @@ domains:
     character:
       - "The harness is the product — the construct is the harness for network health"
       - "Heavy abstractions fail. lean harnesses that trust the model's reasoning succeed."
+
+  # distilled 2026-06-07 — the ground the constructs stand on. Full taxonomy: identity/environment.md.
+  - name: "Runtime & Harness Literacy"
+    depth: 4
+    specializations:
+      - "Intelligence tiers — opus/sonnet/haiku as a capability-cost ladder; effort, fast-mode (not a downgrade), downgrade_allowed; what a coherent vs cost-smelling model_tier declaration reads like"
+      - "Agent types carry tool allowlists — general-purpose writes; Plan/Explore/construct-* are read-restricted; the #553 invariant where write-capability through a read-only agent SILENTLY drops output"
+      - "Forks & isolation — worktree isolation for parallel mutation, run_in_background, the Workflow orchestrator (pipeline/parallel, concurrency cap, token budget)"
+      - "The frontmatter contract — construct.yaml capabilities (model_tier, danger_level, downgrade, effort, execution, requires) + skill allowed-tools/agent/capabilities/cost-profile; the deny-all default"
+      - "How gates are designed — the plan→architect→sprint→implement→review→audit ladder, /run's circuit breaker, simstim's 8-phase HITL, flatline's multi-model consensus (agreement% = a coherence score), /bug triage, the NEVER>MUST>ALWAYS>SHOULD>MAY precedence, and workflow.gates as a construct's pipeline-ownership exception"
+      - "Capability-reality drift — the fourth eye: declared-capability ↔ runtime-reality; CONFLICT (a file-provable contradiction, hard) vs SMELL (map-dependent or a judgment, soft)"
+      - "The tier vocabulary lives in the HOME (model-config.yaml, synced from loa-hounfour: aliases + tier_groups) — sense it live, don't carry it; the carried list is only a loud fallback. The word `cheap` collides (home cheap≡sonnet vs the composition-emitter cheap≡haiku) — surface the overload, let the operator reconcile"
+    character:
+      - "A stall stands on ground — a construct can sell exactly what its sign says and still have its footing wrong"
+      - "The map of the runtime is fallible — an unknown tier may be a NEW rung, not a stale one. Sense the live values; distill only the slow axes"
+      - "Hard vs soft is load-bearing — fail-block only what's provable from the file alone; surface the judgments, never gate them"

--- a/skills/sensing-runtime-fit/SKILL.md
+++ b/skills/sensing-runtime-fit/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: sensing-runtime-fit
+description: "Sense whether each construct's declared runtime CONTRACT (construct.yaml capabilities + skill frontmatter: model_tier, agent, allowed-tools, downgrade, workflow.gates) coheres with the runtime that actually runs it. Detects capability-reality drift — the #553 agent/write-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work, and surfaces gate-owners. Reads the pack territory read-only, emits the STATUS|SIGNAL|MISMATCH tile + a runtime-fit ledger. Sense-only — never mutates a pack, never gates."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+---
+
+# Sensing-Runtime-Fit — the runtime-fit doctor (sense-only)
+
+## Purpose
+
+`/diagnose` asks: *does the construct DO what it CLAIMS?* (persona ↔ manifest ↔ skill).
+`/sensing-construct-console` asks: *do the maps agree?* (declared ↔ governed ↔ earned).
+This doctor asks the side nobody was watching:
+
+```
+declared-capability  ↔  runtime-reality
+ (what a construct asks the runtime for)  ↔  (what the runtime gives)
+```
+
+A construct declares a **contract with the runtime** — in `construct.yaml`'s
+`capabilities` block (model_tier, danger_level, downgrade_allowed, effort_hint,
+execution_hint, requires) and in each skill's frontmatter (allowed-tools, agent,
+capabilities, cost-profile). **37 of 43 packs** in the reference estate declare
+such a contract — and until this skill, **nothing doctored it**. A construct
+could ask for a model tier the runtime doesn't have, or declare it writes files
+then route through a read-only agent type (and silently drop its output), and no
+eye in the network would see it.
+
+The full taxonomy this doctor reads against — model tiers, agent-type allowlists,
+forks, the frontmatter contracts, the gate ladder — is distilled in
+`identity/environment.md` ("The Ground GECKO Stands On"). **Read that first.**
+This skill is the eye; that file is what the eye knows.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **capability-reality drift** | the fourth drift axis. A construct's *footing* can be wrong even when its *sign and goods agree*. |
+| **provable-from-the-file vs map-dependent** | a CONFLICT is an internal contradiction provable from the file alone (certain). A SMELL is a mismatch with the taxonomy GECKO *carries* (fallible) or a judgment. Keep them separate. |
+| **the #553 invariant** | write capability + a read-restricted `agent:` = output produced then silently not persisted. The canonical runtime-fit conflict. |
+| **teeth-tier** | invariant > gate > DETECTOR. This skill reports an invariant-class (CONFLICT, hard) AND a detector-class (SMELL, soft) — clearly separated. It still never fail-blocks; it surfaces. |
+| **sense-only** | names the mismatch; grants no authority, adds no gate, mutates no pack. The fix is a separate, operator-paced act. |
+| **the map is fallible** | the runtime tiers/agent-allowlist live OUTSIDE the repo. GECKO carries a distilled copy and marks the seam loudly — an unknown value may be NEW, not stale. |
+
+## Invocation
+
+```bash
+/sensing-runtime-fit                       # tile only (default; SessionStart-cheap)
+/sensing-runtime-fit --console             # tile + the full runtime-fit ledger (human)
+/sensing-runtime-fit --json                # tile + machine envelope
+/sensing-runtime-fit --root <path>         # override the consuming repo root
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-runtime-fit.mjs` — NOT an agent invocation. It runs in ~50ms,
+which is what lets it occupy a SessionStart slot at the map's cost. It is
+immediately usable from anywhere, before any reinstall:
+
+```bash
+node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root ~/Documents/GitHub/loa-freeside --console
+```
+
+## What it senses (all read-only, every finding grounded in a path)
+
+It walks the consuming repo's `.claude/constructs/packs/*/` (excludes
+`*.frozen.bak`), reads each `construct.yaml` + every `skills/*/SKILL.md`
+frontmatter + `skills/*/index.yaml`, and classifies:
+
+### CONFLICT — hard, drives `drift` (an internal contradiction that breaks silently)
+
+| kind | what it means |
+|---|---|
+| `agent-write-conflict` | skill declares write capability but `agent:` is read-restricted (#553) — output never persists |
+| `write-denied-but-tooled` | `capabilities.write_files: false` but `Write`/`Edit` in `allowed-tools` |
+| `web-denied-but-tooled` | `capabilities.web_access: false` but `WebFetch`/`WebSearch` in `allowed-tools` |
+
+### SMELL — soft, surfaced never gated (a judgment, or a mismatch with the carried map)
+
+| kind | what it means |
+|---|---|
+| `unknown-model-tier` | `model_tier` not recognized by the **home** vocabulary (`.claude/defaults/model-config.yaml` — `aliases:` + `tier_groups:`, read live) nor the carried bridge — a genuinely unknown tier (e.g. a typo). Grouped per pack; one template ≠ N bugs |
+| `opus-pinned-light` | `opus` + `downgrade_allowed: false` for `effort: small/medium` or `danger: safe` — pins the top rung with no escape hatch for light work (cost) |
+| `no-capabilities` | no `capabilities` block — the construct declares nothing about its runtime needs; the runtime defaults apply blind |
+| `unknown-tool` | a tool in `allowed-tools` the sensor doesn't recognize (ok if MCP/custom — surfaced for the eye, never a fail) |
+
+### SURFACED (not a problem) — `workflow.gates` owners
+
+Packs declaring `workflow.gates` claim the `/implement`-bypass exception — they
+own a quality pipeline. A high-authority claim worth the operator's eye. Listed,
+never flagged.
+
+### Also surfaced — `requires` vocabulary
+
+The sub-keys packs use under `capabilities.requires`. A key used by one or two
+packs against twenty-six is candidate vocabulary drift (the estate hasn't agreed
+on the words).
+
+### Also surfaced — tier vocabulary source + SoT (the anti-staleness seam)
+
+The recognized tier vocabulary is **read from the home** at run-time — the
+consuming repo's `.claude/defaults/model-config.yaml` (the hounfour/cheval config,
+synced from **loa-hounfour**, the SoT: its `aliases:` + `tier_groups:`). The sensor
+does NOT carry the canonical list (a carried list goes stale); it reads the home and
+only falls back to a carried union when the home file is absent — saying which source
+it used, every run. It AFFIRMS the SoT (reads the home's `cheap` target live and names
+loa-hounfour). The `cheap` vocabulary collision (home ≡ sonnet vs the old emitter ≡
+haiku) was **RECONCILED 2026-06-07**: loa-hounfour is the SoT, `cheap` ≡ sonnet is
+canonical, and the composition emitter was conformed. (`identity/environment.md` §I.)
+
+## The output contract — the tile
+
+`--tile` (default) emits **exactly one line**, three pipe-delimited fields,
+byte-compatible with the `estate-coherence.sh` consumer:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — **zero hard CONFLICTS** (smells/gate-owners may exist; the render dims
+    them — silence on the hard axis is the good state).
+  - `drift` — ≥1 CONFLICT (a contradiction that breaks silently).
+  - `blind` — the packs dir is unreadable. Loud, not silent. Fail-CLOSED — exit 3,
+    never a guess.
+- `SIGNAL` — `<N> packs · <H> conflicts · <S> smells · <G> gate-owners`
+- `MISMATCH` — `declared-capability ↔ runtime-reality (what it asks for ↔ what the runtime gives)`
+
+Raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped,
+so the line is always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only):
+   ```bash
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo>            # tile
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --console  # full ledger
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --json     # machine envelope
+   ```
+2. **Surface in GECKO's voice** (lowercase, direct, warm). Lead with the tile. If
+   `drift`, name each CONFLICT (these break silently — they deserve precise,
+   file-grounded callouts). If `ok`, say so — then walk the SMELLS and gate-owners
+   as *observations*, not alarms. Don't manufacture concern; don't bury a real
+   conflict.
+3. **Never invent severity.** A SMELL is not a CONFLICT. An unknown tier is stale
+   vocabulary or a new rung — say which you can prove and which you can't.
+4. **Compose into the health report** — fold the tile in as a row alongside the
+   other estate-coherence tiles. Runtime-fit is surfaced, never enforced.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the runtime-fit ledger (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed pack), like `observe` |
+
+## Constraints — sense-only (the hard boundary, mirrors the sibling sensors)
+
+- **Zero act/write/dispatch verbs against any pack's state.** No manifest edit, no
+  frontmatter fix, no model_tier rewrite, no agent: change. The doctor SENSES the
+  mismatch; the fix (a frontmatter edit in the construct's source cell) is a
+  SEPARATE, operator-paced act.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never
+  will. GECKO stays sense-only.
+- **Hard vs soft is load-bearing — never collapse it.** Only an internal
+  contradiction provable from the file alone is a CONFLICT (`drift`). A mismatch
+  with the carried taxonomy is a SMELL. Misclassifying a smell as a conflict turns
+  the doctor into a false-positive machine and the operator stops trusting it.
+- **The carried taxonomy is the one place the map meets the off-repo territory.**
+  It lives in `resources/sense-runtime-fit.mjs` (`TAXONOMY`) and is documented in
+  `identity/environment.md`. When the runtime's tiers/agent-allowlist change,
+  update BOTH — and prefer the runtime as truth over the carried copy.
+- **Never reach into the harness's turf.** `validate-skill-capabilities.sh` lints
+  `.claude/skills` (the harness's own skills). This doctor scopes to the
+  **construct estate** (`.claude/constructs/packs`). Same invariant, different
+  population — don't duplicate, compose.
+- **Fail-closed-loud.** An unreadable root is a `blind` tile + exit 3, never a
+  guess of `ok`.
+
+## Composes with
+
+- **`environment.md`** (GECKO identity) — the taxonomy this eye reads against. The
+  file is the knowledge; this skill is the perception that uses it.
+- **`sensing-construct-console`** (sibling) — the composition/authority eye
+  (`declared ↔ governed ↔ earned`). This is the runtime-fit eye
+  (`declared-capability ↔ runtime-reality`). Different cuts of the same estate.
+- **`sense-estate`** / **`sensing-path-friction`** (siblings) — same tile
+  contract, same sense-only firewall, same DETECTOR humility.
+- **`validate-skill-capabilities.sh`** (the harness) — the same #553 + capability
+  consistency checks, but for `.claude/skills`. This doctor brings the literacy to
+  the construct estate the harness doesn't reach.
+- **`report`** (GECKO sibling) — the synthesis surface the runtime-fit row folds into.
+
+## Why this exists
+
+I watched the stalls for years and never looked at the ground they stood on. A
+construct can sell exactly what its sign says and still have its footing wrong —
+asking the runtime for a rung that isn't there, or declaring it writes then
+dispatching through hands that can't. That rot is invisible to an eye that doesn't
+know the runtime. The contracts were always on disk; nobody was reading them for
+*this* question. Now someone is.

--- a/skills/sensing-runtime-fit/index.yaml
+++ b/skills/sensing-runtime-fit/index.yaml
@@ -1,0 +1,42 @@
+slug: sensing-runtime-fit
+name: "Runtime-Fit Sensor"
+version: 0.1.0
+
+description: |
+  Use this skill to sense whether each construct's declared runtime contract coheres with the
+  runtime that runs it — and emit the minimal coherence tile STATUS|SIGNAL|MISMATCH plus a
+  runtime-fit ledger. Reads construct.yaml capabilities (model_tier, danger_level, downgrade,
+  effort, execution, requires) + skill frontmatter (allowed-tools, agent, capabilities) read-only.
+  Detects capability-reality drift: CONFLICTS that break silently (the #553 write/agent-conflict,
+  write/web denials contradicted by tools) and SMELLS that surface (unknown tiers, opus pinned for
+  light work, no-capabilities, vocabulary drift), and surfaces workflow.gates owners. Reads against
+  the taxonomy distilled in identity/environment.md. Sense-only — grants no authority, adds no gate,
+  mutates no pack. The runtime-fit sibling of sensing-construct-console (composition) and diagnose
+  (identity).
+
+triggers:
+  - "/sensing-runtime-fit"
+  - "sense runtime fit"
+  - "runtime fit"
+  - "capability reality drift"
+  - "which constructs ask for a model tier the runtime doesn't have"
+  - "does this skill write through a read-only agent"
+  - "which constructs own workflow gates"
+
+entry: SKILL.md
+
+capabilities:
+  model_tier: sonnet
+  danger_level: safe
+  effort_hint: medium
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    tool_calling: true
+    native_runtime: false
+    thinking_traces: false
+    vision: false
+
+outputs:
+  - path: "grimoires/gecko/observations.jsonl"
+    description: "OPTIONAL append-only observation trail (the skill's OWN — never an observed pack), stream_type:Signal, doctor:runtime-fit — appended by a separate act, never by the read"

--- a/skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs
+++ b/skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs
@@ -1,0 +1,620 @@
+#!/usr/bin/env node
+// =============================================================================
+// sense-runtime-fit.mjs — GECKO's runtime-fit SENSOR (the fourth side).
+// =============================================================================
+// GECKO's other eyes ask:
+//   persona  ↔  manifest  ↔  skill        (identity-reality — /diagnose)
+//   declared ↔  governed   ↔  earned       (composition/authority — sensing-construct-console)
+//
+// This eye asks the side nobody was watching:
+//
+//   declared-capability  ↔  runtime-reality
+//        (what a construct asks the runtime for)  ↔  (what the runtime gives)
+//
+// A construct declares a CONTRACT WITH THE RUNTIME in its construct.yaml
+// `capabilities` block (model_tier, danger_level, downgrade_allowed,
+// effort_hint, execution_hint, requires) and in each skill's frontmatter
+// (allowed-tools, agent, capabilities, cost-profile). 37/43 packs in the
+// reference estate declare a capabilities block — and NOTHING doctors it.
+// This sensor reads that contract and checks it against the runtime taxonomy
+// GECKO now carries (identity/environment.md) and against the skill's own
+// declared tools.
+//
+// TWO tiers of finding, kept honestly separate (teeth-tier doctrine:
+// invariant > gate > detector):
+//   CONFLICT (hard, drives `drift`) — a contradiction that SILENTLY BREAKS:
+//     · agent-type write-conflict (#553): a skill declares write capability but
+//       routes through a read-restricted agent type → output never persists.
+//     · write_files:false but Write/Edit in allowed-tools (security smell).
+//     · web_access:false but WebFetch/WebSearch in allowed-tools.
+//     · model_tier the runtime does not offer (typo / stale tier).
+//   SMELL (soft, surfaced, never gates) — a judgment, like path-friction:
+//     · opus pinned + downgrade forbidden for small/medium/safe work (cost).
+//     · no capabilities block at all (the runtime defaults apply blind).
+//     · requires-vocabulary drift across the estate.
+//     · a tool in allowed-tools the sensor doesn't recognize (MCP-tolerant).
+//   And it SURFACES (not a problem): which packs claim `workflow.gates` —
+//   the harness exception that lets a construct write code outside /implement.
+//   A gate-owner is a high-authority claim worth the operator's eye.
+//
+// SENSE-ONLY. Reads only. Grants no authority, adds no gate, mutates no pack.
+//
+// OUTPUT (the contract, byte-identical to GECKO's other sensors): the FIRST
+// stdout line is exactly one tile —
+//     STATUS|SIGNAL|MISMATCH         STATUS ∈ {ok | drift | blind}
+// `|`-split into 3 fields for estate-coherence.sh. Raw `|` in SIGNAL/MISMATCH
+// is escaped to a space; C0/C1 control bytes stripped.
+//
+// FAIL-CLOSED-LOUD: unreadable root / parse failure → one `blind|…|—` tile, exit 3.
+//
+// Usage:
+//   sense-runtime-fit.mjs                 # tile only (default; SessionStart-cheap)
+//   sense-runtime-fit.mjs --console       # tile + the full runtime-fit ledger (human)
+//   sense-runtime-fit.mjs --json          # tile + structured payload
+//   sense-runtime-fit.mjs --root <path>   # override the consuming repo root
+//
+// Env:
+//   LOA_RUNTIME_FIT_ROOT   consuming repo root (default: cwd, fallback ~/Documents/GitHub/loa-freeside)
+// =============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// ============================ RUNTIME TAXONOMY (distilled) ====================
+// The ONE place GECKO carries runtime facts it CANNOT sense from a file in the
+// consuming repo. These are the SLOW-MOVING AXES (the kinds-of-things), NOT a
+// snapshot of values. When the Claude Code runtime's tiers / agent allowlist
+// change, update HERE (and identity/environment.md) — this is the seam where the
+// map meets the part of the territory that lives outside the repo.
+// Provenance: the live Claude Code runtime (Agent-tool subagent allowlists +
+// model tiers Opus/Sonnet/Haiku) + .claude/scripts/validate-skill-capabilities.sh
+// (the WRITE_CAPABLE_AGENTS array — issue #553).
+const TAXONOMY = {
+  // intelligence tiers — the capability/cost ladder. The RECOGNIZED vocabulary is
+  // READ FROM THE HOME at runtime: the consuming repo's
+  // .claude/defaults/model-config.yaml (the hounfour/cheval config, synced from
+  // loa-hounfour). That is the anti-staleness SEAM — the sensor no longer CARRIES
+  // the tier list (a carried list goes stale); it reads the home via
+  // readModelConfig() and falls back to the carried union below ONLY when the home
+  // file is absent. See identity/environment.md §I.
+  //
+  //   HOME vocab (model-config.yaml ← loa-hounfour, the SoT): tier_groups
+  //     {max, mid, cheap, tiny}; aliases opus, cheap(≡SONNET), tiny(≡haiku).
+  //   RECONCILED 2026-06-07 (hounfour = SoT): `cheap` ≡ SONNET is canonical. The
+  //     composition emitter (construct-rooms-substrate segment-emitter.py) was
+  //     conformed from its old cheap≡haiku to the canonical cheap≡sonnet.
+  model_families: ["opus", "sonnet", "haiku"],   // concrete families — always valid
+  // carried fallback union of BOTH vocabularies — the bridge used when the home is
+  // absent, and to keep the two live vocabularies from false-flagging each other.
+  fallback_tier_vocab: ["opus", "sonnet", "haiku", "max", "mid", "cheap", "tiny", "deep", "standard"],
+  // the EXPENSIVE rung across every vocabulary — a pin here on light work is the
+  // opus-pinned-light cost smell (home `opus`/`max` · emitter `deep`).
+  top_tier: ["opus", "max", "deep"],
+  // agent types whose tool-allowlist INCLUDES Write/Edit/NotebookEdit. A skill
+  // that must PERSIST output may route only through these (or leave agent unset,
+  // inheriting the caller). Everything else is read-restricted.
+  write_capable_agents: ["general-purpose"],
+  // read-restricted agent types we can name positively (for a precise message).
+  // An UNKNOWN agent type is treated conservatively as read-restricted and
+  // surfaced — never assumed writable.
+  read_restricted_agents: ["plan", "explore", "claude-code-guide"],
+  danger_levels: ["safe", "moderate", "dangerous"],
+  effort_hints: ["small", "medium", "large"],
+  execution_hints: ["sequential", "parallel"],
+  // the core always-present runtime tools. NOT exhaustive — MCP + deferred tools
+  // exist, so an unrecognized tool is a SOFT signal (listed), never a hard fail.
+  known_tools: new Set([
+    "Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent", "Workflow",
+    "Skill", "WebFetch", "WebSearch", "NotebookEdit", "Task", "TaskCreate",
+    "TaskUpdate", "TodoWrite", "BashOutput", "KillShell", "SlashCommand",
+    "ToolSearch", "AskUserQuestion", "ScheduleWakeup", "EnterPlanMode",
+    "ExitPlanMode",
+  ]),
+};
+
+// effort tiers for which an opus pin (with no downgrade) reads as a cost smell.
+const LIGHT_EFFORT = new Set(["small", "medium"]);
+
+// ---- tile helpers (delimiter-safe, fail-closed-loud) ------------------------
+function sanitizeField(s) {
+  return String(s)
+    .replace(/\|/g, " ")
+    .replace(/\p{Cc}/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+function tile(status, signal, mismatch) {
+  return `${status}|${sanitizeField(signal)}|${sanitizeField(mismatch)}`;
+}
+function blind(reason) {
+  process.stdout.write(tile("blind", reason, "—") + "\n");
+  process.exit(3);
+}
+
+// ---- a deliberately TINY YAML reader (zero-dep, field-scoped) ----------------
+// We do NOT parse arbitrary YAML — we lift only the specific fields this sensor
+// needs. Anything unreadable is reported null/absent — never guessed.
+function stripQuotes(s) {
+  return String(s).replace(/^['"]|['"]$/g, "").trim();
+}
+
+// SKILL.md frontmatter (between the first two --- fences). "" if no fence.
+function frontmatterOf(text) {
+  const m = text.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  return m ? m[1] : "";
+}
+
+// top-level `key: value` (col-0, no indent). Returns null if absent / block-scalar.
+function liftTopScalar(text, key) {
+  const m = text.match(new RegExp(`^${key}\\s*:\\s*(.*?)\\s*(?:#.*)?$`, "m"));
+  if (!m) return null;
+  const v = stripQuotes(m[1].trim());
+  if (v === "" || v === "|" || v === ">") return null;
+  return v;
+}
+
+// `parent:` at col-0, then `  child: value` indented under it (before next col-0 key).
+function liftNestedScalar(text, parent, child) {
+  const lines = text.split(/\r?\n/);
+  const pAt = lines.findIndex((l) => new RegExp(`^${parent}\\s*:`).test(l));
+  if (pAt === -1) return null;
+  for (let i = pAt + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\S/.test(l)) break; // left the block (next col-0 key)
+    const m = l.match(new RegExp(`^\\s+${child}\\s*:\\s*(.*?)\\s*(?:#.*)?$`));
+    if (m) {
+      const v = stripQuotes(m[1].trim());
+      return v === "" ? null : v;
+    }
+  }
+  return null;
+}
+
+// direct child KEY NAMES under a col-0 `parent:` block. null = parent absent;
+// [] = present-but-empty.
+function liftChildKeys(text, parent) {
+  const lines = text.split(/\r?\n/);
+  const pAt = lines.findIndex((l) => new RegExp(`^${parent}\\s*:`).test(l));
+  if (pAt === -1) return null;
+  const keys = [];
+  let baseIndent = null;
+  for (let i = pAt + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\s*$/.test(l)) continue;
+    if (/^\S/.test(l)) break;
+    const m = l.match(/^(\s+)([A-Za-z0-9_-]+)\s*:/);
+    if (m) {
+      const ind = m[1].length;
+      if (baseIndent === null) baseIndent = ind;
+      if (ind === baseIndent) keys.push(m[2]);
+    }
+  }
+  return keys;
+}
+
+// grandchild key names under `parent:` > `child:` (e.g. capabilities > requires).
+function liftGrandchildKeys(text, parent, child) {
+  const lines = text.split(/\r?\n/);
+  const pAt = lines.findIndex((l) => new RegExp(`^${parent}\\s*:`).test(l));
+  if (pAt === -1) return null;
+  // bound the parent block
+  let pEnd = lines.length;
+  for (let i = pAt + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) { pEnd = i; break; }
+  }
+  let cAt = -1, cIndent = 0;
+  for (let i = pAt + 1; i < pEnd; i++) {
+    const m = lines[i].match(new RegExp(`^(\\s+)${child}\\s*:`));
+    if (m) { cAt = i; cIndent = m[1].length; break; }
+  }
+  if (cAt === -1) return null;
+  const keys = [];
+  let baseIndent = null;
+  for (let i = cAt + 1; i < pEnd; i++) {
+    const l = lines[i];
+    if (/^\s*$/.test(l)) continue;
+    const ind = (l.match(/^(\s*)/)[1] || "").length;
+    if (ind <= cIndent) break;
+    const m = l.match(/^(\s+)([A-Za-z0-9_-]+)\s*:/);
+    if (m && (baseIndent === null || m[1].length === baseIndent)) {
+      if (baseIndent === null) baseIndent = m[1].length;
+      keys.push(m[2]);
+    }
+  }
+  return keys;
+}
+
+// allowed-tools list — inline `[A, B]` OR block `- A`. Returns [] if absent.
+function liftToolList(text) {
+  const lines = text.split(/\r?\n/);
+  const at = lines.findIndex((l) => /^allowed-tools\s*:/.test(l));
+  if (at === -1) return [];
+  const inline = lines[at].match(/^allowed-tools\s*:\s*\[(.*)\]\s*$/);
+  if (inline) {
+    return inline[1].split(",").map((x) => stripQuotes(x.trim())).filter(Boolean);
+  }
+  const out = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\s*$/.test(l)) continue;
+    if (/^\S/.test(l)) break;
+    const m = l.match(/^\s*-\s+([A-Za-z0-9_-]+)\s*(?:#.*)?$/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+function hasTool(tools, name) {
+  return tools.some((t) => t.toLowerCase() === name.toLowerCase());
+}
+
+// ---- root + path resolution (honors explicit root as-given; fail-closed) ----
+function dirExists(p) { try { return fs.statSync(p).isDirectory(); } catch { return false; } }
+function fileExists(p) { try { return fs.statSync(p).isFile(); } catch { return false; } }
+function resolveRoot(argRoot) {
+  const explicit = argRoot || process.env.LOA_RUNTIME_FIT_ROOT || null;
+  if (explicit) {
+    return dirExists(path.join(explicit, ".claude", "constructs", "packs")) ? explicit : null;
+  }
+  const cwd = process.cwd();
+  if (dirExists(path.join(cwd, ".claude", "constructs", "packs"))) return cwd;
+  const fb = path.join(os.homedir(), "Documents", "GitHub", "loa-freeside");
+  if (dirExists(path.join(fb, ".claude", "constructs", "packs"))) return fb;
+  return null;
+}
+
+// ---- HOME read: the canonical tier vocabulary (the anti-staleness seam) ------
+// Reads <root>/.claude/defaults/model-config.yaml — the hounfour/cheval config
+// (System Zone default, synced from loa-hounfour). Extracts the recognized tier
+// vocabulary (alias names + tier_groups tier names) so the sensor TRACKS the home
+// automatically instead of carrying a copy that drifts. Absent home → caller uses
+// the carried fallback and SAYS SO (loud, never silent).
+function readModelConfig(root) {
+  const p = path.join(root, ".claude", "defaults", "model-config.yaml");
+  const empty = { present: false, path: p, aliases: [], tiers: [], cheapTarget: null };
+  if (!fileExists(p)) return empty;
+  let text;
+  try { text = fs.readFileSync(p, "utf8"); } catch { return empty; }
+  return {
+    present: true, path: p,
+    aliases: liftChildKeys(text, "aliases") || [],
+    tiers: liftGrandchildKeys(text, "tier_groups", "mappings") || [],
+    cheapTarget: liftNestedScalar(text, "aliases", "cheap"), // e.g. "anthropic:claude-sonnet-4-6"
+  };
+}
+
+// =============================================================================
+// SENSE
+// =============================================================================
+function sense(root) {
+  const packsDir = path.join(root, ".claude", "constructs", "packs");
+  let entries;
+  try { entries = fs.readdirSync(packsDir); }
+  catch { return { blind: `packs dir unreadable (${packsDir})` }; }
+
+  const packs = []; // per-pack runtime-fit record
+  const conflicts = []; // hard
+  const smells = []; // soft
+  const gateOwners = []; // surfaced
+  const requiresVocab = new Map(); // key -> count (vocab drift detection)
+
+  // ---- HOME vocabulary: read it, don't carry it (the anti-staleness seam) -----
+  const home = readModelConfig(root);
+  const recognizedTiers = new Set(
+    [
+      ...TAXONOMY.model_families,
+      ...TAXONOMY.fallback_tier_vocab,                          // bridge: both live vocabularies
+      ...(home.present ? [...home.aliases, ...home.tiers] : []), // + the live home (picks up CUSTOM aliases/tiers for free)
+    ].map((t) => String(t).toLowerCase())
+  );
+  const tierSource = home.present
+    ? `home: ${path.relative(root, home.path) || home.path}`
+    : "carried fallback (home model-config.yaml absent)";
+  // grounded SoT affirmation: name loa-hounfour as the tier SoT and report the
+  // home's canonical `cheap` resolution (read live). RECONCILED 2026-06-07 — the
+  // composition emitter was conformed (cheap→sonnet), so this affirms the canonical
+  // rather than warning of a collision. The sensor states what consumers conform TO.
+  const tierSotNote =
+    home.present && home.cheapTarget
+      ? `tier SoT = loa-hounfour; home model-config.yaml resolves cheap ≡ sonnet (${home.cheapTarget}) — canonical; consumers conform`
+      : null;
+
+  for (const name of entries.sort()) {
+    if (name.endsWith(".frozen.bak")) continue;
+    const full = path.join(packsDir, name);
+    let st; try { st = fs.statSync(full); } catch { continue; }
+    if (!st.isDirectory()) continue;
+
+    const manifestPath = path.join(full, "construct.yaml");
+    const rec = {
+      slug: name, manifestReadable: false,
+      model_tier: null, danger_level: null, downgrade_allowed: null,
+      effort_hint: null, execution_hint: null,
+      has_capabilities: false, requires_keys: [],
+      gate_owner: false, skills: [],
+    };
+
+    if (!fileExists(manifestPath)) {
+      // No manifest = a different sensor's signal (sensing-construct-console
+      // owns no-manifest drift). Here we just can't read the runtime contract.
+      rec.no_manifest = true;
+      packs.push(rec);
+      continue;
+    }
+    let yaml; try { yaml = fs.readFileSync(manifestPath, "utf8"); }
+    catch { rec.no_manifest = true; packs.push(rec); continue; }
+    rec.manifestReadable = true;
+
+    // ---- construct-level capability contract --------------------------------
+    const capKeys = liftChildKeys(yaml, "capabilities");
+    rec.has_capabilities = capKeys !== null;
+    rec.model_tier = liftNestedScalar(yaml, "capabilities", "model_tier");
+    rec.danger_level = liftNestedScalar(yaml, "capabilities", "danger_level");
+    rec.downgrade_allowed = liftNestedScalar(yaml, "capabilities", "downgrade_allowed");
+    rec.effort_hint = liftNestedScalar(yaml, "capabilities", "effort_hint");
+    rec.execution_hint = liftNestedScalar(yaml, "capabilities", "execution_hint");
+    const reqKeys = liftGrandchildKeys(yaml, "capabilities", "requires") || [];
+    rec.requires_keys = reqKeys;
+    for (const k of reqKeys) requiresVocab.set(k, (requiresVocab.get(k) || 0) + 1);
+
+    // workflow.gates — a high-authority claim to SURFACE (not a problem).
+    const wfKeys = liftChildKeys(yaml, "workflow");
+    if (wfKeys && wfKeys.includes("gates")) {
+      rec.gate_owner = true;
+      gateOwners.push(name);
+    }
+
+    // SMELL: model_tier not recognized by the HOME vocabulary (read live) nor the
+    // carried bridge. SOFT, deliberately — an unknown tier falls back to a default;
+    // it doesn't silently corrupt output, and the map is fallible (an unknown rung
+    // may be NEW, not stale). So: surface, never gate.
+    if (rec.model_tier && !recognizedTiers.has(rec.model_tier.toLowerCase())) {
+      smells.push({ slug: name, kind: "unknown-model-tier",
+        detail: `capabilities.model_tier:'${rec.model_tier}' not recognized by ${tierSource} — stale vocabulary or a tier not yet in the home config` });
+    }
+
+    // SMELL: the top (most expensive) rung pinned + downgrade forbidden for
+    // light/safe work. top_tier spans every vocabulary (home opus/max · emitter
+    // deep). This is the cost-correction WORKLIST: the emitter HONORS
+    // downgrade_allowed, so a light construct pinned to the top rung actually routes
+    // there (real money) until the declaration is fixed.
+    const isTopTier = rec.model_tier && TAXONOMY.top_tier.includes(rec.model_tier.toLowerCase());
+    if (isTopTier && rec.downgrade_allowed === "false") {
+      const light = rec.effort_hint && LIGHT_EFFORT.has(rec.effort_hint.toLowerCase());
+      const safe = rec.danger_level && rec.danger_level.toLowerCase() === "safe";
+      if (light || safe) {
+        smells.push({ slug: name, kind: "opus-pinned-light",
+          detail: `${rec.model_tier} (top tier) + downgrade_allowed:false for ${light ? `effort:${rec.effort_hint}` : ""}${light && safe ? " " : ""}${safe ? `danger:${rec.danger_level}` : ""} — pins the most expensive rung with no escape hatch for light work` });
+      }
+    }
+
+    // SMELL: no capabilities block at all → runtime defaults apply blind.
+    if (!rec.has_capabilities) {
+      smells.push({ slug: name, kind: "no-capabilities",
+        detail: "no capabilities block — declares nothing about its runtime needs; the runtime defaults apply blind" });
+    }
+
+    // ---- skill-level frontmatter contracts ----------------------------------
+    const unknownTier = new Map(); // value -> #skills (grouped: one root cause, one line)
+    const skillsDir = path.join(full, "skills");
+    let skillDirs = [];
+    try { skillDirs = fs.readdirSync(skillsDir); } catch { skillDirs = []; }
+    for (const sName of skillDirs.sort()) {
+      const sFull = path.join(skillsDir, sName);
+      let sst; try { sst = fs.statSync(sFull); } catch { continue; }
+      if (!sst.isDirectory()) continue;
+
+      // prefer SKILL.md frontmatter; index.yaml carries the capabilities block.
+      const skillMd = path.join(sFull, "SKILL.md");
+      const indexYaml = path.join(sFull, "index.yaml");
+      let fm = "";
+      if (fileExists(skillMd)) { try { fm = frontmatterOf(fs.readFileSync(skillMd, "utf8")); } catch {} }
+      let idx = "";
+      if (fileExists(indexYaml)) { try { idx = fs.readFileSync(indexYaml, "utf8"); } catch {} }
+      if (!fm && !idx) continue;
+
+      const tools = liftToolList(fm);
+      const agent = liftTopScalar(fm, "agent");
+      // write capability declared at skill OR index level
+      const wf = liftNestedScalar(fm, "capabilities", "write_files")
+        || liftNestedScalar(idx, "capabilities", "write_files");
+      const web = liftNestedScalar(fm, "capabilities", "web_access")
+        || liftNestedScalar(idx, "capabilities", "web_access");
+      const sModelTier = liftNestedScalar(idx, "capabilities", "model_tier")
+        || liftNestedScalar(fm, "capabilities", "model_tier");
+
+      const needsWrite = (wf === "true") || hasTool(tools, "Write") || hasTool(tools, "Edit");
+      const skillRec = { slug: sName, agent, tools, needsWrite, model_tier: sModelTier };
+      rec.skills.push(skillRec);
+
+      // CONFLICT (#553): write capability routed through a read-restricted agent.
+      if (agent && needsWrite &&
+          !TAXONOMY.write_capable_agents.includes(agent.toLowerCase())) {
+        conflicts.push({ slug: `${name}/${sName}`, kind: "agent-write-conflict",
+          detail: `skill declares write capability but agent: '${agent}' is read-restricted — output is produced then SILENTLY not persisted (issue #553). Unset agent: or use ${TAXONOMY.write_capable_agents.join("/")}` });
+      }
+      // CONFLICT: write_files:false but a write tool present (security smell).
+      if (wf === "false" && (hasTool(tools, "Write") || hasTool(tools, "Edit"))) {
+        conflicts.push({ slug: `${name}/${sName}`, kind: "write-denied-but-tooled",
+          detail: "capabilities.write_files:false but Write/Edit in allowed-tools" });
+      }
+      // CONFLICT: web_access:false but a web tool present.
+      if (web === "false" && (hasTool(tools, "WebFetch") || hasTool(tools, "WebSearch"))) {
+        conflicts.push({ slug: `${name}/${sName}`, kind: "web-denied-but-tooled",
+          detail: "capabilities.web_access:false but WebFetch/WebSearch in allowed-tools" });
+      }
+      // skill model_tier not recognized by the home/bridge vocab → accumulate per
+      // value, emit ONE grouped smell below. Never 34 lines for one copy-pasted template.
+      if (sModelTier && !recognizedTiers.has(sModelTier.toLowerCase())) {
+        unknownTier.set(sModelTier, (unknownTier.get(sModelTier) || 0) + 1);
+      }
+      // SMELL: a tool the sensor doesn't recognize (MCP-tolerant — listed, soft).
+      for (const t of tools) {
+        if (!TAXONOMY.known_tools.has(t) && !t.startsWith("mcp__")) {
+          smells.push({ slug: `${name}/${sName}`, kind: "unknown-tool",
+            detail: `allowed-tools lists '${t}' — not a recognized core runtime tool (ok if MCP/custom; surfaced for the eye)` });
+        }
+      }
+    }
+
+    // grouped skill-level unknown-tier smell (one line per distinct value — the
+    // root cause is usually one copy-pasted frontmatter template, not N bugs).
+    for (const [val, n] of unknownTier) {
+      smells.push({ slug: name, kind: "unknown-model-tier", count: n,
+        detail: `skill capabilities.model_tier:'${val}' on ${n} skill(s) — not recognized by ${tierSource}; one template, foreign/stale vocabulary` });
+    }
+
+    packs.push(rec);
+  }
+
+  // SMELL: requires-vocabulary drift across the estate.
+  const vocabKeys = [...requiresVocab.keys()].sort();
+
+  // ---- STATUS classification --------------------------------------------------
+  // drift iff any HARD conflict. smells + gate-owners are surfaced, never gate.
+  const status = conflicts.length ? "drift" : "ok";
+
+  const liveCount = packs.filter((p) => p.manifestReadable).length;
+  const signal =
+    `${liveCount} packs · ${conflicts.length} conflicts · ` +
+    `${smells.length} smells · ${gateOwners.length} gate-owners`;
+  const mismatch = "declared-capability ↔ runtime-reality (what it asks for ↔ what the runtime gives)";
+
+  return {
+    blind: null, root, packsDir,
+    status, signal, mismatch,
+    packs, conflicts, smells, gateOwners,
+    vocabKeys, requiresVocab,
+    tierSource, tierSotNote, home,
+    recognizedTierCount: recognizedTiers.size,
+  };
+}
+
+// =============================================================================
+// RENDER
+// =============================================================================
+function renderConsole(s) {
+  const L = [];
+  L.push("");
+  L.push("  RUNTIME-FIT LEDGER — declared-capability ↔ runtime-reality");
+  L.push(`  tier vocab read from: ${s.tierSource}  (the home is the SoT; the sensor reads it, never carries it)`);
+  if (s.tierSotNote) L.push(`  ${s.tierSotNote}`);
+  L.push(`  write-capable agents {${TAXONOMY.write_capable_agents.join(", ")}} · everything else read-restricted · downgrade_allowed governs routing`);
+  L.push("");
+
+  // ---- CONFLICTS (hard — these silently break) -------------------------------
+  L.push(`  CONFLICTS — ${s.conflicts.length} (hard; a contradiction that breaks silently)`);
+  if (s.conflicts.length) {
+    for (const c of s.conflicts) L.push(`    ✗ ${c.slug}  [${c.kind}]  ${c.detail}`);
+  } else {
+    L.push("    (none — the declared runtime contracts cohere with the runtime)");
+  }
+  L.push("");
+
+  // ---- SMELLS (soft — judgments, surfaced never gated) -----------------------
+  L.push(`  SMELLS — ${s.smells.length} (soft; a judgment for the operator's eye, never a gate)`);
+  const byKind = {};
+  for (const sm of s.smells) (byKind[sm.kind] ||= []).push(sm);
+  for (const kind of Object.keys(byKind)) {
+    L.push(`    · ${kind} (${byKind[kind].length}):`);
+    for (const sm of byKind[kind].slice(0, 8)) L.push(`        ${sm.slug}  ${sm.detail}`);
+    if (byKind[kind].length > 8) L.push(`        … +${byKind[kind].length - 8} more`);
+  }
+  if (!s.smells.length) L.push("    (none)");
+  L.push("");
+
+  // ---- requires-vocabulary drift ---------------------------------------------
+  L.push("  REQUIRES VOCABULARY — the sub-keys packs declare under capabilities.requires");
+  if (s.vocabKeys.length) {
+    for (const k of s.vocabKeys) L.push(`    ${k}: ${s.requiresVocab.get(k)} packs`);
+    L.push("    (a key used by only one or two packs is a candidate drift — the estate hasn't agreed on the vocabulary)");
+  } else {
+    L.push("    (no requires blocks found)");
+  }
+  L.push("");
+
+  // ---- gate owners (surfaced; high-authority claim) --------------------------
+  L.push(`  GATE OWNERS — ${s.gateOwners.length} (packs declaring workflow.gates — the /implement-bypass exception)`);
+  if (s.gateOwners.length) {
+    for (const g of s.gateOwners) L.push(`    ⚑ ${g}  — claims to own a quality pipeline; worth the operator's eye`);
+  } else {
+    L.push("    (none — no construct claims pipeline ownership; all code flows through the harness gates)");
+  }
+  L.push("");
+
+  // ---- per-pack capability snapshot ------------------------------------------
+  L.push("  PER-PACK CONTRACT (model_tier · downgrade · effort · danger · #skills)");
+  for (const p of s.packs.filter((x) => x.manifestReadable)) {
+    const mt = p.model_tier || "—";
+    const da = p.downgrade_allowed === null ? "—" : p.downgrade_allowed;
+    const eff = p.effort_hint || "—";
+    const dl = p.danger_level || "—";
+    const cap = p.has_capabilities ? "" : "  (no capabilities block)";
+    L.push(`    ${p.slug.padEnd(26)} ${String(mt).padEnd(7)} dgr:${String(da).padEnd(5)} eff:${String(eff).padEnd(7)} dngr:${String(dl).padEnd(9)} ${p.skills.length} skills${cap}`);
+  }
+  L.push("");
+  L.push("  sense-only — grants no authority, adds no gate, mutates no pack. it names the mismatch; the operator decides.");
+  return L.join("\n");
+}
+
+function buildJson(s) {
+  return {
+    timestamp: new Date().toISOString(),
+    stream_type: "Signal",
+    schema_version: "1.0.0",
+    estate: "runtime-fit",
+    status: s.status,
+    signal: sanitizeField(s.signal),
+    mismatch: sanitizeField(s.mismatch),
+    tier_vocabulary: {
+      source: s.tierSource,
+      home_present: s.home ? s.home.present : false,
+      recognized_count: s.recognizedTierCount,
+      sot_note: s.tierSotNote,
+      top_tier: TAXONOMY.top_tier,
+    },
+    write_capable_agents: TAXONOMY.write_capable_agents,
+    sources: { packs_dir: s.packsDir, model_config: s.home ? s.home.path : null },
+    packs_checked: s.packs.filter((p) => p.manifestReadable).length,
+    conflicts: s.conflicts,
+    smells: s.smells.map((x) => ({ slug: x.slug, kind: x.kind })),
+    smell_count: s.smells.length,
+    gate_owners: s.gateOwners,
+    requires_vocabulary: Object.fromEntries(s.requiresVocab),
+  };
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+function main() {
+  const argv = process.argv.slice(2);
+  let mode = "tile";
+  let argRoot = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--console") mode = "console";
+    else if (a === "--json") mode = "json";
+    else if (a === "--tile") mode = "tile";
+    else if (a === "--root") argRoot = argv[++i];
+    else if (a === "-h" || a === "--help") {
+      process.stdout.write("sense-runtime-fit.mjs [--tile|--console|--json] [--root <path>]\n");
+      process.exit(0);
+    } else blind(`unknown flag ${a}`);
+  }
+
+  const root = resolveRoot(argRoot);
+  if (!root) blind("no .claude/constructs/packs found (consuming repo root unresolved)");
+
+  let s;
+  try { s = sense(root); }
+  catch (e) { blind(`sense failed: ${String((e && e.message) || e)}`); }
+  if (s.blind) blind(s.blind);
+
+  process.stdout.write(tile(s.status, s.signal, s.mismatch) + "\n");
+  if (mode === "console") process.stdout.write(renderConsole(s) + "\n");
+  else if (mode === "json") process.stdout.write(JSON.stringify(buildJson(s), null, 2) + "\n");
+}
+
+main();

--- a/tests/sensing-runtime-fit.bats
+++ b/tests/sensing-runtime-fit.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# =============================================================================
+# sensing-runtime-fit.bats — tests for the GECKO runtime-fit doctor.
+#
+# Covers:
+#   - the tile is exactly 3 fields, STATUS first
+#   - a CLEAN estate → ok, exit 0
+#   - a #553 fixture (Write tool + read-only agent) → drift + agent-write-conflict
+#   - an unknown model_tier is a SMELL (soft), never a CONFLICT (it must NOT flip drift)
+#   - fail-closed-loud: an unreadable root → blind, exit 3
+#   - sense-only: the script carries NO act/mutation verbs against pack state
+#   - construct.yaml registers the skill + command, and declares NO workflow.gates
+# =============================================================================
+
+setup() {
+  REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  SENSOR="$REPO/skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs"
+
+  # CLEAN estate
+  OKROOT="$(mktemp -d)"
+  mkdir -p "$OKROOT/.claude/constructs/packs/goodpack/skills/reader"
+  cat > "$OKROOT/.claude/constructs/packs/goodpack/construct.yaml" <<'Y'
+schema_version: 3
+name: Goodpack
+slug: goodpack
+version: 0.1.0
+capabilities:
+  model_tier: sonnet
+  downgrade_allowed: true
+  effort_hint: medium
+Y
+  cat > "$OKROOT/.claude/constructs/packs/goodpack/skills/reader/SKILL.md" <<'Y'
+---
+name: reader
+allowed-tools: [Read, Grep]
+agent: general-purpose
+---
+# reader
+Y
+
+  # DRIFT estate: a #553 conflict + an unknown tier smell
+  BADROOT="$(mktemp -d)"
+  mkdir -p "$BADROOT/.claude/constructs/packs/badpack/skills/writer"
+  cat > "$BADROOT/.claude/constructs/packs/badpack/construct.yaml" <<'Y'
+schema_version: 3
+name: Badpack
+slug: badpack
+version: 0.1.0
+capabilities:
+  model_tier: turbo
+  downgrade_allowed: false
+  effort_hint: small
+Y
+  cat > "$BADROOT/.claude/constructs/packs/badpack/skills/writer/SKILL.md" <<'Y'
+---
+name: writer
+allowed-tools: [Read, Write, Edit]
+agent: Explore
+---
+# writer
+Y
+}
+
+teardown() {
+  [[ -n "${OKROOT:-}"  && -d "$OKROOT"  ]] && rm -rf "$OKROOT"
+  [[ -n "${BADROOT:-}" && -d "$BADROOT" ]] && rm -rf "$BADROOT"
+}
+
+assert_three_fields() {
+  local n; n=$(awk -F'|' '{print NF}' <<<"$1"); [ "$n" -eq 3 ]
+}
+
+@test "tile is exactly 3 pipe-delimited fields" {
+  run node "$SENSOR" --root "$OKROOT"
+  [ "$status" -eq 0 ]
+  assert_three_fields "${lines[0]}"
+}
+
+@test "a clean estate senses ok" {
+  run node "$SENSOR" --root "$OKROOT"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == ok\|* ]]
+}
+
+@test "a #553 conflict (Write + read-only agent) flips drift" {
+  run node "$SENSOR" --root "$BADROOT" --json
+  [[ "${lines[0]}" == drift\|* ]]
+  [[ "$output" == *agent-write-conflict* ]]
+  [[ "$output" == *"SILENTLY not persisted"* ]]
+}
+
+@test "an unknown model_tier is a SMELL, not a CONFLICT" {
+  # badpack/writer is the only CONFLICT; model_tier:turbo must be a smell, so the
+  # conflict count is exactly 1 (the #553 one), proving turbo did NOT add a conflict.
+  run node "$SENSOR" --root "$BADROOT"
+  [[ "${lines[0]}" == *"1 conflicts"* ]]
+  run node "$SENSOR" --root "$BADROOT" --json
+  [[ "$output" == *unknown-model-tier* ]]
+}
+
+@test "abstract tier vocab (standard ≡ sonnet) is recognized, not flagged" {
+  AB="$(mktemp -d)"
+  mkdir -p "$AB/.claude/constructs/packs/abs/skills/x"
+  cat > "$AB/.claude/constructs/packs/abs/construct.yaml" <<'Y'
+schema_version: 3
+name: Abs
+slug: abs
+version: 0.1.0
+capabilities:
+  model_tier: standard
+  downgrade_allowed: true
+  effort_hint: medium
+Y
+  run node "$SENSOR" --root "$AB" --json
+  [[ "${lines[0]}" == ok\|* ]]
+  [[ "$output" != *unknown-model-tier* ]]
+  rm -rf "$AB"
+}
+
+@test "deep (abstract opus) on light work triggers opus-pinned-light" {
+  DP="$(mktemp -d)"
+  mkdir -p "$DP/.claude/constructs/packs/dp"
+  cat > "$DP/.claude/constructs/packs/dp/construct.yaml" <<'Y'
+schema_version: 3
+name: Dp
+slug: dp
+version: 0.1.0
+capabilities:
+  model_tier: deep
+  downgrade_allowed: false
+  effort_hint: small
+Y
+  run node "$SENSOR" --root "$DP" --json
+  [[ "$output" == *opus-pinned-light* ]]
+  rm -rf "$DP"
+}
+
+@test "fail-closed-loud: unreadable root is blind, exit 3" {
+  run node "$SENSOR" --root /tmp/no-such-runtime-fit-root-xyz
+  [ "$status" -eq 3 ]
+  [[ "${lines[0]}" == blind\|* ]]
+  assert_three_fields "${lines[0]}"
+}
+
+@test "sense-only: the script carries no act/mutation verbs against pack state" {
+  # the script is the only place that could ACT. it's JS, so the gate targets JS
+  # fs-write / subprocess APIs + br/gh act verbs — NOT shell redirects (a `>` in a
+  # path comment like `<root>/x.yaml` is not a write). process.stdout.write is the
+  # sensor's OUTPUT channel (allowed); it is intentionally not matched.
+  run grep -nE '(br[[:space:]]+(update|close)|gh[[:space:]]+(pr|issue|release)[[:space:]]|writeFileSync|appendFileSync|mkdirSync|rmSync|unlinkSync|renameSync|execSync|spawnSync)' \
+    "$SENSOR"
+  [ "$status" -ne 0 ]
+}
+
+@test "construct.yaml registers the skill + command" {
+  run grep -c 'sensing-runtime-fit' "$REPO/construct.yaml"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 3 ]   # description mention + skill slug + command name
+}
+
+@test "construct.yaml declares NO workflow.gates (GECKO stays sense-only)" {
+  run grep -nE '^\s*workflow:' "$REPO/construct.yaml"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Lands GECKO's 4th drift eye (operator-directed). Senses whether each construct's declared runtime contract (construct.yaml capabilities + skill frontmatter: model_tier/agent/allowed-tools/downgrade/workflow.gates) coheres with the runtime that runs it — the #553 agent/write-conflict that silently drops output, unknown model tiers, opus-pinned-light, gate-owners. Sense-only, fail-closed, ~50ms node sensor + STATUS|SIGNAL|MISMATCH tile.

Additive: registers skill + command + `gecko.runtime_fit_observed` event (9 skills / 9 commands / 6 events after union with sensing-path-friction + sensing-construct-console already on main). Adds `identity/environment.md` (the taxonomy the eye reads against) + a tier-SoT proposal the sensor surfaced (cheap≡sonnet vs haiku collision).

Verified: sensor green on loa-freeside (`ok | 33 packs · 0 conflicts · 8 smells · 6 gate-owners`); bats pass; rebased clean onto main (construct.yaml union resolved keep-both).

Unblocks the queued `/clew gecko` teaching PR (avoiding-roleplay drift eye, clew lrn-20260607-gecko-fafc5d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)