### PR TITLE
docs(clew): distill 3 ripe gecko clews (three-gates · gradient-slip · reward-loop-health)

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -32,6 +32,8 @@ skills:
     path: skills/sensing-construct-console
   - slug: sensing-runtime-fit
     path: skills/sensing-runtime-fit
+  - slug: sensing-deployment-seam
+    path: skills/sensing-deployment-seam
 
 commands:
   - name: patrol

--- a/skills/patrol/SKILL.md
+++ b/skills/patrol/SKILL.md
@@ -46,6 +46,22 @@ For each cycle:
 2. Read the emitted observation from `observations.jsonl`
 3. Compare `health_score` against `baseline_score`
 
+### Step 2.5: Reward-Loop Health (the RLAIHF dimension)
+
+Patrol senses the construct LEARNING loop, not just declared-vs-runtime fit. Read the clew
+ledgers (`~/.loa/constructs/packs/*/LEARNINGS.jsonl`; `node ~/bonfire/clew-loop.mjs` where
+present) and compare CAPTURE RATE against operator activity:
+
+| Condition | Reading |
+|---|---|
+| heavy operator activity + pending clews accumulating | loop healthy — the backlog is the drain's (`/clew <construct>`) |
+| heavy operator activity + near-zero capture | loop UNDER-FIRING — root cause is UPSTREAM of capture: main-loop work isn't routed THROUGH constructs, so corrections never become construct-targeted clews. Surface as drift; the fix is routing (`/compose`, construct agentTypes), not more capture tooling. |
+| capture without distillation for >2 weeks | teachings rotting in the ledger — surface the ripe constructs |
+
+Lesson (clew lrn-20260607-gecko-2f35ed): only ~4 clews existed ecosystem-wide despite heavy
+operator activity. An under-fed reward loop looks like silence — and silence reads as health
+unless patrol measures the loop ITSELF as a drift dimension.
+
 ### Step 3: Ratchet Decision
 
 | Condition | Action |

--- a/skills/sensing-construct-console/resources/sense-construct-console.mjs
+++ b/skills/sensing-construct-console/resources/sense-construct-console.mjs
@@ -73,11 +73,26 @@ function blind(reason) {
 // Anything unreadable is reported UNKNOWN — never guessed.
 function readManifestFields(text) {
   const lines = text.split(/\r?\n/);
-  const out = { compose_with: null, reads: null, writes: null };
+  const out = { compose_with: null, reads: null, writes: null, genome_depth: 0, genome_hash: null };
 
   // top-level key = column-0, `key:` form.
   const topIdx = (key) =>
     lines.findIndex((l) => new RegExp(`^${key}\\s*:`).test(l));
+
+  // ---- genome chain depth (EARNED authority via clew-merge — bd-uze) ----------
+  // genome_depth/genome_hash are additive top-level PROVENANCE (NOT the behavioral
+  // interface). Depth = conviction = earned authority; 0 = no genome yet. SHADOW:
+  // surfaced here, not yet a routing/gate input.
+  const gdAt = topIdx("genome_depth");
+  if (gdAt !== -1) {
+    const m = lines[gdAt].match(/^genome_depth\s*:\s*(\d+)/);
+    if (m) out.genome_depth = parseInt(m[1], 10);
+  }
+  const ghAt = topIdx("genome_hash");
+  if (ghAt !== -1) {
+    const m = lines[ghAt].match(/^genome_hash\s*:\s*(sha256:[0-9a-f]{64})/);
+    if (m) out.genome_hash = m[1];
+  }
 
   // ---- compose_with (top-level only — author's hand-written intent) ----------
   const cwAt = topIdx("compose_with");
@@ -220,6 +235,8 @@ function sense(root) {
       compose_with: f.compose_with || [],
       reads: f.reads || [],
       writes: f.writes || [],
+      genome_depth: f.genome_depth || 0,
+      genome_hash: f.genome_hash || null,
     });
   }
 
@@ -291,6 +308,17 @@ function sense(root) {
     .filter((p) => !(authority[p.slug] > 0))
     .map((p) => p.slug);
 
+  // ---- GENOME depth: earned authority via clew-merge (bd-uze, SHADOW) ---------
+  // A second, independent earned-authority signal (complements the closed-row
+  // ledger): genome_depth = count of operator-merged, run-verified clews a
+  // construct has absorbed. Surfaced; NOT yet a routing/gate input (shadow-first).
+  const withGenome = live
+    .filter((p) => p.manifestReadable && p.genome_depth > 0)
+    .map((p) => ({ slug: p.slug, depth: p.genome_depth, head: p.genome_hash }))
+    .sort((a, b) => b.depth - a.depth);
+  const genomeTotalDepth = withGenome.reduce((s, p) => s + p.depth, 0);
+  const genomeMaxDepth = withGenome.reduce((m, p) => Math.max(m, p.depth), 0);
+
   // ---- STATUS classification (the estate's own thresholds) -------------------
   // blind: territory unreadable (handled above by early-return)
   // drift: any phantom OR any unmapped-live OR any unreadable manifest OR
@@ -323,6 +351,7 @@ function sense(root) {
     earned, observedPairs,
     deadIntentions, undeclaredDeps,
     authority, authorityUnearned,
+    withGenome, genomeTotalDepth, genomeMaxDepth,
   };
 }
 
@@ -467,6 +496,19 @@ function renderConsole(s) {
       L.push(`    authority_unearned (0 closed): ${s.authorityUnearned.length} constructs`);
   }
   L.push("");
+
+  // ---- GENOME depth (the second earned-authority signal — bd-uze, shadow) ----
+  L.push("  GENOME — earned authority via clew-merge (bd-uze)  [SHADOW: surfaced, not yet routed]");
+  if (s.withGenome.length === 0) {
+    L.push(`    0/${s.live.length} live constructs carry a genome (depth 0 everywhere)`);
+    L.push("    → the clew loop hasn't compounded yet; depth grows only via run-verified --mark-distilled");
+  } else {
+    L.push(`    ${s.withGenome.length}/${s.live.length} carry a genome · total depth ${s.genomeTotalDepth} · deepest ${s.genomeMaxDepth}`);
+    for (const g of s.withGenome.slice(0, 8))
+      L.push(`    🧬 ${g.slug}: genome-depth ${g.depth}  (${g.head ? g.head.slice(0, 19) + "…" : "—"})`);
+    L.push("    deeper chain = more earned conviction = the lower-risk choice (routing on this is the deferred step)");
+  }
+  L.push("");
   L.push("  sense-only — grants no authority, adds no gate, mutates no pack. the act-construct grants.");
   return L.join("\n");
 }
@@ -505,6 +547,12 @@ function buildJson(s) {
       rows: s.earned.rows,
       edges: s.observedPairs.length,
       authority_unearned: s.authorityUnearned.length,
+      genome: {
+        with_genome: s.withGenome.length,
+        total_depth: s.genomeTotalDepth,
+        max_depth: s.genomeMaxDepth,
+        routed: false,
+      },
     },
     gap: {
       dead_intentions: s.deadIntentions.length,

--- a/skills/sensing-deployment-seam/SKILL.md
+++ b/skills/sensing-deployment-seam/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: sensing-deployment-seam
+description: >
+  GECKO's 4th eye — the deployment-seam coherence sensor. The first three eyes
+  look INSIDE a construct (identity-reality, composition-authority, runtime-fit);
+  this one looks AT THE SEAM between where the Loa framework PUTS things (the SoT
+  roots in ~/.loa/deployment.yaml) and where each harness consumer LOOKS for them.
+  It senses the manifest-numbness / scattered-symlink / source-vs-installed-lag
+  class: a consumer expecting an artifact at a root the producer placed elsewhere,
+  silently, until a dispatch breaks. Sense-only. CONFLICT (hard, path-provable) vs
+  SMELL (soft). Use when the same deployment incoherence keeps recurring, after a
+  framework/harness layout change, or as a periodic sweep.
+allowed-tools: [Bash, Read, Grep, Glob]
+agent: construct-gecko
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: false
+  web_access: false
+cost-profile: lightweight
+role: review
+---
+
+# sensing-deployment-seam — the 4th eye
+
+> Authored 2026-06-08 from the `audit-ecosystem-coherence` Opus review. The estate
+> kept re-discovering the same incoherence (manifest-numbness, the `.loa`↔`.claude`
+> path-split, ghost constructs, the sensor that wasn't installed) and patching the
+> instance. This eye senses the CLASS so it is caught before a dispatch breaks.
+
+## The model (operator decision 2026-06-08): single global SoT
+
+`~/.loa/deployment.yaml` names the canonical roots once — `packs / agents / template
+/ runtime / compositions / schema`. Any consumer reading a DIFFERENT pack root is a
+CONFLICT, not a legitimate scope. The eye READS that SoT (so it tracks the home
+automatically and says so when the manifest is absent — a doctor that doctors its
+own map).
+
+## What it senses
+
+- **SEAM-ROOT** — every pack-root consumer must resolve to `packs_root`. The global
+  registration path (`adapter-generator.py`) is probed for its resolved `PACKS_DIR`;
+  any script that hardcodes a non-SoT pack root via path-arithmetic is a CONFLICT;
+  a band-aid symlink bridging the divergence is a SMELL (it encodes the bug).
+- **SEAM-INSTALL-LAG** — pack-bundled scope only. (a) the installed pack must ship
+  every pack-bundled skill IT declares; (b) the installed pack must not LAG its
+  source repo's pack-bundled skills (the `sensing-runtime-fit-not-installed` class
+  this very eye was born from). Harness-installed skills (`path: .claude/skills/…`)
+  are a different scope and are NOT pack lag.
+
+## Run it
+
+```bash
+python3 "$(dirname "$0")/sense.py"          # human-readable
+python3 "$(dirname "$0")/sense.py" --json   # structured (for patrol / the wall)
+```
+
+Exit code is the finding count (for scripting); it NEVER gates — same firewall as
+GECKO's other eyes: it names the mismatch, grants no authority, mutates nothing.
+The fixing is a separate, operator-paced act.
+
+## Composes with
+
+- `sensing-runtime-fit` — the intra-construct capability-reality eye; this is its
+  inter-construct, seam-level sibling.
+- `patrol` — wire `sense.py --json` into the network loop so deployment-seam drift
+  reaches the wall.
+- The deployment SoT (`~/.loa/deployment.yaml`) — the truth this eye reads and checks
+  every consumer against.

--- a/skills/sensing-deployment-seam/sense.py
+++ b/skills/sensing-deployment-seam/sense.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""sensing-deployment-seam — GECKO's 4th eye.
+
+The first three eyes look INSIDE a construct (identity-reality, composition-
+authority, runtime-fit). This one looks AT THE SEAM between where the Loa
+framework PUTS things (the SoT roots) and where each harness consumer LOOKS
+for them. It is the sensor for the deployment-seam class — manifest-numbness,
+scattered symlinks, source<->installed lag, ghost constructs — every instance
+of "a consumer expects an artifact at a root the producer placed elsewhere,
+silently, until a dispatch breaks."
+
+Model (operator decision 2026-06-08): SINGLE GLOBAL SoT. `~/.loa/deployment.yaml`
+names the canonical roots once; any consumer reading a DIFFERENT pack root is a
+CONFLICT, not a legitimate scope.
+
+Sense-only, same firewall as GECKO's other eyes: it NAMES the mismatch, grants
+no authority, mutates nothing. CONFLICT (hard, path-provable) vs SMELL (soft,
+taxonomy/judgment). Exit code is the finding count for scripting; it never gates.
+
+Reads the SoT it checks — so it tracks the home automatically and says so when
+the manifest is absent (anti-staleness seam: a doctor that doctors its own map).
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+MANIFEST = Path(os.environ.get("LOA_DEPLOYMENT_MANIFEST", str(HOME / ".loa" / "deployment.yaml")))
+
+CANONICAL_DEFAULTS = {
+    "packs": "~/.loa/constructs/packs",
+    "agents": "~/.claude/agents",
+    "template": "~/.claude/templates",
+    "compositions": "~/bonfire/construct-compositions/compositions",
+}
+
+
+def _expand(p):
+    return Path(os.path.expanduser(str(p)))
+
+
+def load_roots():
+    """SoT roots: manifest > canonical default. Names the source so absence is loud."""
+    roots, source = dict(CANONICAL_DEFAULTS), "canonical-default (no manifest)"
+    if MANIFEST.is_file():
+        try:
+            import yaml
+
+            declared = (yaml.safe_load(MANIFEST.read_text()) or {}).get("roots", {}) or {}
+            roots.update({k: v for k, v in declared.items() if v})
+            source = str(MANIFEST)
+        except Exception as exc:  # noqa: BLE001 — a malformed SoT is itself a finding
+            source = f"{MANIFEST} (UNREADABLE: {exc})"
+    return {k: _expand(v) for k, v in roots.items()}, source
+
+
+def finding(sev, seam, consumer, expects, actual, evidence):
+    return {"severity": sev, "seam": seam, "consumer": consumer,
+            "expects": str(expects), "actual": str(actual), "evidence": evidence}
+
+
+def sense_root_coherence(roots):
+    """SEAM-ROOT: every pack-root consumer must read packs_root. Any other root = CONFLICT.
+    Band-aid symlinks bridging the divergence = SMELL (they encode the bug, not fix it)."""
+    out = []
+    packs = roots["packs"]
+    if not packs.is_dir():
+        out.append(finding("CONFLICT", "root", "SoT packs_root", packs, "MISSING",
+                            f"packs_root from {'manifest' if MANIFEST.is_file() else 'default'} does not exist"))
+        return out
+
+    # The global registration consumer: does adapter-generator resolve to packs_root?
+    ag = HOME / ".claude" / "scripts" / "lib" / "adapter-generator.py"
+    if ag.is_file():
+        try:
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location("ag_probe", ag)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            resolved = Path(os.path.realpath(getattr(mod, "PACKS_DIR")))
+            if resolved != Path(os.path.realpath(packs)):
+                out.append(finding("CONFLICT", "root", "adapter-generator.py", packs, resolved,
+                                    "global registration reads a pack root != SoT packs_root"))
+        except Exception as exc:  # noqa: BLE001
+            out.append(finding("SMELL", "root", "adapter-generator.py", packs, f"unprobeable ({exc})",
+                               "could not import to confirm its resolved PACKS_DIR"))
+
+    # Band-aid symlinks that bridge the .loa<->.claude divergence (should be retired).
+    for link in (HOME / ".claude" / "constructs", HOME / ".claude" / "scripts" / "templates"):
+        if link.is_symlink():
+            out.append(finding("SMELL", "root", str(link), "(retired)", os.readlink(link),
+                               "band-aid symlink bridging divergent roots — encodes the bug; retire once consumers read the SoT"))
+
+    # Other consumers that still hardcode the WRONG global pack root (path-arithmetic from an
+    # installed location lands on HOME -> ~/.claude/constructs/packs, which is not packs_root).
+    scripts_dir = HOME / ".claude" / "scripts"
+    bad = HOME / ".claude" / "constructs" / "packs"
+    if scripts_dir.is_dir() and Path(os.path.realpath(packs)) != Path(os.path.realpath(bad)):
+        for sh in scripts_dir.rglob("*.sh"):
+            if ".bak" in sh.name:
+                continue
+            try:
+                txt = sh.read_text(errors="ignore")
+            except OSError:
+                continue
+            # a LIVE assignment (not a comment) of a pack dir to PROJECT_ROOT/.claude/constructs/packs
+            for m in re.finditer(r"^[^#\n]*?([A-Z_]+)=.*\.claude/constructs/packs", txt, re.MULTILINE):
+                out.append(finding("CONFLICT", "root", sh.name, packs, "~/.claude/constructs/packs",
+                                   f"assigns {m.group(1)} to a non-SoT pack root (line: {m.group(0).strip()[:80]})"))
+                break
+    return out
+
+
+def _pack_bundled_skills(yaml_path):
+    """(slug, pack-relative-path) for PACK-BUNDLED skills only. Skills whose declared path is
+    under .claude/skills (harness-installed, a different scope — e.g. hivemind-os) are NOT
+    pack lag and are excluded. Returns None if the yaml is unreadable."""
+    try:
+        import yaml
+
+        data = yaml.safe_load(Path(yaml_path).read_text()) or {}
+    except Exception:  # noqa: BLE001
+        return None
+    out = []
+    for s in data.get("skills") or []:
+        if isinstance(s, str):
+            out.append((s, f"skills/{s}"))
+        elif isinstance(s, dict):
+            slug = s.get("slug") or s.get("name") or s.get("id")
+            path = s.get("path")
+            if not slug:
+                continue
+            if path and (".claude/" in str(path) or str(path).startswith("/")):
+                continue  # harness-installed skill — different scope, not pack-bundled lag
+            out.append((slug, path or f"skills/{slug}"))
+    return out
+
+
+def sense_install_lag(roots):
+    """SEAM-INSTALL-LAG (the sensing-runtime-fit-not-installed class). Two precise checks,
+    pack-bundled scope only: (a) the installed pack must SHIP every pack-bundled skill IT
+    declares; (b) the installed pack must not LAG its source repo's pack-bundled skills."""
+    out = []
+    packs = roots["packs"]
+    if not packs.is_dir():
+        return out
+    gh = HOME / "Documents" / "GitHub"
+    for pack in sorted(packs.iterdir()):
+        if not pack.is_dir() or pack.name.endswith(".bak"):
+            continue
+        inst_yaml = pack / "construct.yaml"
+        if not inst_yaml.is_file():
+            continue
+        sdir = pack / "skills"
+        inst_dirs = {p.name for p in sdir.iterdir() if p.is_dir()} if sdir.is_dir() else set()
+
+        # (a) installed self-consistency: every pack-bundled skill the installed yaml declares must exist.
+        for slug, rel in (_pack_bundled_skills(inst_yaml) or []):
+            if not (pack / rel).is_dir():
+                out.append(finding("CONFLICT", "install-lag", f"{pack.name}/{slug}", f"pack/{rel}", "absent",
+                                   f"installed construct.yaml declares pack-bundled {rel}/ but it is missing"))
+
+        # (b) source -> installed: if a local source repo exists, the installed pack must not lag the
+        #     skills the SOURCE declares pack-bundled (how the review caught gecko's 9th skill).
+        src_yaml = gh / f"construct-{pack.name}" / "construct.yaml"
+        if src_yaml.is_file():
+            for slug, _ in (_pack_bundled_skills(src_yaml) or []):
+                if slug not in inst_dirs:
+                    out.append(finding("CONFLICT", "install-lag", f"{pack.name}/{slug}",
+                                       "installed (source ships it)", "absent",
+                                       f"source construct-{pack.name} declares pack-bundled '{slug}' but the installed "
+                                       f"pack lacks skills/{slug}/ — installed lags source"))
+    return out
+
+
+def main():
+    roots, source = load_roots()
+    findings = sense_root_coherence(roots) + sense_install_lag(roots)
+    as_json = "--json" in sys.argv
+    if as_json:
+        print(json.dumps({"sot_source": source, "packs_root": str(roots["packs"]), "findings": findings}, indent=2))
+    else:
+        c = sum(1 for f in findings if f["severity"] == "CONFLICT")
+        s = sum(1 for f in findings if f["severity"] == "SMELL")
+        print(f"∴ sensing-deployment-seam  ·  SoT: {source}")
+        print(f"  packs_root: {roots['packs']}")
+        print(f"  {c} CONFLICT · {s} SMELL\n")
+        for f in findings:
+            mark = "✗" if f["severity"] == "CONFLICT" else "~"
+            print(f"  {mark} [{f['severity']}] {f['seam']}: {f['consumer']}")
+            print(f"      expects {f['expects']}  ·  actual {f['actual']}")
+            print(f"      {f['evidence']}")
+        if not findings:
+            print("  (no deployment-seam drift sensed — consumers agree with the SoT)")
+    return len(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/sensing-deployment-seam/sense.py
+++ b/skills/sensing-deployment-seam/sense.py
@@ -177,9 +177,53 @@ def sense_install_lag(roots):
     return out
 
 
+def load_substrate_constructs():
+    """The declared substrate constructs from the SoT manifest (the 'different kind' of
+    construct — runtime + deck, not skill-packs)."""
+    if not MANIFEST.is_file():
+        return []
+    try:
+        import yaml
+
+        data = yaml.safe_load(MANIFEST.read_text()) or {}
+        return data.get("substrate_constructs") or []
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def sense_substrate_home(roots, substrates):
+    """SEAM-SUBSTRATE-HOME: each declared substrate construct must be INSTALLED at its SoT
+    home (substrates/<name>, a real dir). Symlinked to a dev source (the runtime-symlink->
+    branch seam) or read from ~/bonfire is the scatter — a CONFLICT."""
+    out = []
+    sub_root = roots.get("substrates")
+    if not sub_root or not substrates:
+        return out
+    for s in substrates:
+        name = s.get("name") if isinstance(s, dict) else s
+        if not name:
+            continue
+        install = sub_root / name
+        if install.is_dir() and not install.is_symlink():
+            continue  # at its SoT home — good
+        where = "absent"
+        if install.is_symlink():
+            where = f"SYMLINK -> {os.readlink(install)}"
+        else:
+            for legacy in (HOME / ".loa" / "runtime" / name, HOME / "bonfire" / name, HOME / "Documents" / "GitHub" / name):
+                if legacy.exists():
+                    tgt = f" -> {os.readlink(legacy)}" if legacy.is_symlink() else ""
+                    where = f"at {legacy}{tgt}"
+                    break
+        out.append(finding("CONFLICT", "substrate-home", name, str(install), where,
+                           f"substrate construct not at its SoT home; {where} — re-home to substrates/<name>"))
+    return out
+
+
 def main():
     roots, source = load_roots()
-    findings = sense_root_coherence(roots) + sense_install_lag(roots)
+    findings = (sense_root_coherence(roots) + sense_install_lag(roots)
+                + sense_substrate_home(roots, load_substrate_constructs()))
     as_json = "--json" in sys.argv
     if as_json:
         print(json.dumps({"sot_source": source, "packs_root": str(roots["packs"]), "findings": findings}, indent=2))

--- a/skills/sensing-path-friction/SKILL.md
+++ b/skills/sensing-path-friction/SKILL.md
@@ -29,7 +29,7 @@ operator/agent decides. There is no action slot.
 |---|---|
 | **mounted-agent posture** | act on your OWN cell directly; act on ANOTHER cell only by spawning an agent INSIDE it. Reaching in from outside = a posture slip. |
 | **the path gradient** | right-size the path to the task: L0 write-own · L1 spawn-in-cell · L2 `/coord` (coordinator + branch + review-gated PR) · L3 `/compose`. Pick the LIGHTEST path that fits (cost-of-failure × reversibility × blast-radius). |
-| **the consumption gradient** | the regenerative path must be the path of LEAST resistance. If the correct path is steeper than reaching-in, agents reach in. |
+| **the consumption gradient** | the regenerative path must be the path of LEAST resistance. If the correct path is steeper than reaching-in, agents reach in. OBSERVED LIVE (2026-06-06, clew lrn-20260606-gecko-a7fce3): an agent bypassed `/compose` for 4 consecutive builds despite compose-doctor reporting READY — raw Workflow was lighter than compiling a composition. a READY doctor does not mean the governed path is the least-resistance path; sense the WEIGHT DELTA (governed-path steps vs raw-path steps), not just availability. |
 | **done-twice-becomes-a-path** | a recurring manual cross-cell act → auto-PROPOSE a lightweight composable rail (floor-raise, not a bespoke per-task tile). |
 | **teeth-tier** | invariant > gate > DETECTOR. This is a DETECTOR. surface-not-decide. |
 

--- a/skills/sensing-runtime-fit/SKILL.md
+++ b/skills/sensing-runtime-fit/SKILL.md
@@ -42,6 +42,17 @@ This skill is the eye; that file is what the eye knows.
 | **teeth-tier** | invariant > gate > DETECTOR. This skill reports an invariant-class (CONFLICT, hard) AND a detector-class (SMELL, soft) — clearly separated. It still never fail-blocks; it surfaces. |
 | **sense-only** | names the mismatch; grants no authority, adds no gate, mutates no pack. The fix is a separate, operator-paced act. |
 | **the map is fallible** | the runtime tiers/agent-allowlist live OUTSIDE the repo. GECKO carries a distilled copy and marks the seam loudly — an unknown value may be NEW, not stale. |
+| **roleplay-vulnerability** | the RAIL edition of capability-reality drift. a deterministic loop EXISTS but nothing REQUIRES its artifact — so an LLM asked to "run" it SIMULATES the output instead (native next-token plausibility, not malice). a rail is roleplay-vulnerable when faking its output is cheaper than running it. cure flips COST (un-fakeable trace + a check that requires it + downstream that consumes the trace, not the agent's word) — adds no compute. "we already had the code" ≠ load-bearing. |
+
+### Rails vs seams (where the eye looks, and where it must NOT)
+
+avoid-roleplay is a RAIL property, never a seam one. a rail is deterministic transport
+between judgments — INVOKED, never simulated; sense it for an un-fakeable run-trace + a
+check that requires it (proof-of-run: no trace = not_a_run) + downstream consuming the
+trace. a SEAM (a gate, an operator pairing, a construct's own reasoning) is where roleplay
+IS the work. the eye flags a rail that can be faked cheaply; it leaves seams alone. a
+proof-of-run gate verifies the TRANSPORT happened, never the judgment's quality. misread a
+seam as a rail → you gate creativity; misread a rail as a seam → you trust a simulation.
 
 ## Invocation
 

--- a/skills/sensing-runtime-fit/SKILL.md
+++ b/skills/sensing-runtime-fit/SKILL.md
@@ -43,6 +43,7 @@ This skill is the eye; that file is what the eye knows.
 | **sense-only** | names the mismatch; grants no authority, adds no gate, mutates no pack. The fix is a separate, operator-paced act. |
 | **the map is fallible** | the runtime tiers/agent-allowlist live OUTSIDE the repo. GECKO carries a distilled copy and marks the seam loudly — an unknown value may be NEW, not stale. |
 | **roleplay-vulnerability** | the RAIL edition of capability-reality drift. a deterministic loop EXISTS but nothing REQUIRES its artifact — so an LLM asked to "run" it SIMULATES the output instead (native next-token plausibility, not malice). a rail is roleplay-vulnerable when faking its output is cheaper than running it. cure flips COST (un-fakeable trace + a check that requires it + downstream that consumes the trace, not the agent's word) — adds no compute. "we already had the code" ≠ load-bearing. |
+| **three-gates-in-series** | environment design = three gates in SERIES: **formation** (can the game form — players registered, present, connected) → **observability** (is cooperation visible via an un-fakeable artifact) → **payoff** (defect/stick/(3,3)). most stuck rails fail at formation or observability, NOT payoff — sense the failing LAYER first; tuning payoff on a rail that can't form is wasted hardness. hardness law: a PreToolUse hook is a real gradient; SKILL.md prose is roleplay-vulnerable. (clew lrn-20260607-gecko-0b460c) |
 
 ### Rails vs seams (where the eye looks, and where it must NOT)
 
@@ -117,7 +118,11 @@ only falls back to a carried union when the home file is absent — saying which
 it used, every run. It AFFIRMS the SoT (reads the home's `cheap` target live and names
 loa-hounfour). The `cheap` vocabulary collision (home ≡ sonnet vs the old emitter ≡
 haiku) was **RECONCILED 2026-06-07**: loa-hounfour is the SoT, `cheap` ≡ sonnet is
-canonical, and the composition emitter was conformed. (`identity/environment.md` §I.)
+canonical. **CAUTION — sensed 2026-06-09: the emitter-conformance half never reached the
+territory.** `segment-emitter.py` HEAD and the deployed substrate copy
+(`~/.loa/constructs/substrates/…`) still map `cheap → haiku`; the conforming change
+exists only as an unlanded WIP commit (`1e0b5d6`). a decision record is a map — verify
+the routing table in the territory before trusting `cheap`. (`identity/environment.md` §I.)
 
 ## The output contract — the tile
 


### PR DESCRIPTION
## Clew drain — /clew gecko

Drains the 3 pending clews from `~/.loa/constructs/packs/gecko/LEARNINGS.jsonl` per the drain contract (teaching edits to principle/doctrine blocks only; `construct.yaml` untouched):

| clew | target skill | teaching |
|---|---|---|
| `lrn-20260607-gecko-0b460c` | sensing-runtime-fit | **three-gates-in-series** doctrine row: formation → observability → payoff; most stuck rails fail at formation/observability, NOT payoff — sense the failing LAYER first. Hook = real gradient; prose = roleplay-vulnerable. |
| `lrn-20260606-gecko-a7fce3` | sensing-path-friction | consumption-gradient slip **observed live**: agent bypassed /compose for 4 builds despite doctor READY. Sense the weight DELTA, not just availability. |
| `lrn-20260607-gecko-2f35ed` | patrol | **Step 2.5 reward-loop-health** (RLAIHF dimension): under-fed loop looks like silence; measure the loop itself. |

## Bonus correction (sensed 2026-06-09)

`sensing-runtime-fit/SKILL.md` claimed the cheap≡sonnet emitter conformance landed. The territory disagrees: `segment-emitter.py` HEAD **and** the deployed substrate copy still map `cheap→haiku`; the conforming change exists only as unlanded WIP `1e0b5d6` in construct-rooms-substrate. The doc now states the honest seam.

## Note on the stack

This branch carries the unmerged `feat/sensing-deployment-seam` stack (4 commits incl. `99fa857`, the prior clew `fafc5d` roleplay-eye teaching). Merging closes BOTH clew loops. If you'd rather land the 4th-eye stack separately, merge that first and this rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)