### PR TITLE
feat(sensing): sensing-belt-progress for Belt sync ETA/stalls

### DIFF
--- a/skills/sensing-belt-progress/SKILL.md
+++ b/skills/sensing-belt-progress/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: sensing-belt-progress
+description: "Sense sonar-api Belt sync progression (Envio chain_metadata) via the belt-progress substrate — tip lag, stall class, ETA. GECKO tile + --json. Sense-only; never sets ENVIO_RESTART."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+---
+
+# Sensing-Belt-Progress (GECKO lens)
+
+Sense-only eye for the **sonar-api** Belt indexer. The substrate lives in the consuming repo:
+
+```bash
+# From sonar-api root (preferred)
+node scripts/belt-progress.mjs --tile
+node scripts/belt-progress.mjs --robot-triage --json
+
+# Or via this skill's wrapper (resolves SONAR_API_ROOT / sibling checkout)
+node skills/sensing-belt-progress/resources/sense-belt-progress.mjs
+node skills/sensing-belt-progress/resources/sense-belt-progress.mjs --json
+```
+
+## Env
+
+| Var | Role |
+|-----|------|
+| `SONAR_API_ROOT` | Path to sonar-api checkout (default: `~/Documents/GitHub/sonar-api`) |
+| `BELT_GRAPHQL_URL` | Hasura GraphQL (default public sonar gateway) |
+
+## Tile
+
+`STATUS|SIGNAL|MISMATCH` with `STATUS ∈ {ok|drift|blind}` — byte-compatible with estate-coherence consumers.
+
+## Hard rule
+
+Never set `ENVIO_RESTART`. KF-013 wipe/resume is operator Railway procedure.

--- a/skills/sensing-belt-progress/index.yaml
+++ b/skills/sensing-belt-progress/index.yaml
@@ -1,0 +1,27 @@
+slug: sensing-belt-progress
+name: "Belt Progress Sensor"
+version: 0.1.0
+
+description: |
+  GECKO lens over sonar-api scripts/belt-progress.mjs — Belt sync tip/stall/ETA.
+  Sense-only. Never sets ENVIO_RESTART.
+
+triggers:
+  - "/sensing-belt-progress"
+  - "belt progress"
+  - "envio stall"
+  - "chain sync eta"
+
+entry: SKILL.md
+
+capabilities:
+  model_tier: sonnet
+  danger_level: safe
+  effort_hint: small
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    tool_calling: true
+    native_runtime: false
+    thinking_traces: false
+    vision: false

--- a/skills/sensing-belt-progress/resources/sense-belt-progress.mjs
+++ b/skills/sensing-belt-progress/resources/sense-belt-progress.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// GECKO wrapper — resolves sonar-api substrate and delegates (sense-only).
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function resolveSonarRoot() {
+  const env = process.env.SONAR_API_ROOT?.trim();
+  if (env && existsSync(join(env, "scripts/belt-progress.mjs"))) return env;
+  const sibling = join(homedir(), "Documents/GitHub/sonar-api");
+  if (existsSync(join(sibling, "scripts/belt-progress.mjs"))) return sibling;
+  return null;
+}
+
+const root = resolveSonarRoot();
+if (!root) {
+  process.stdout.write(
+    "blind|0 chains · sonar-api substrate missing|set SONAR_API_ROOT to sonar-api checkout\n",
+  );
+  process.exit(3);
+}
+
+const substrate = join(root, "scripts/belt-progress.mjs");
+const argv = process.argv.slice(2);
+const flags = new Set(argv);
+
+let args;
+if (flags.has("--sample")) {
+  args = ["sample", "--samples", "2", "--interval", "15", "--json"];
+} else if (flags.has("--console")) {
+  args = ["--robot-triage"];
+} else if (flags.has("--json")) {
+  const tile = spawnSync(process.execPath, [substrate, "--tile"], {
+    encoding: "utf8",
+    cwd: root,
+    env: process.env,
+  });
+  process.stdout.write(tile.stdout || "");
+  if (tile.status === 3) process.exit(3);
+  const triage = spawnSync(process.execPath, [substrate, "--robot-triage", "--json"], {
+    encoding: "utf8",
+    cwd: root,
+    env: process.env,
+  });
+  process.stdout.write(triage.stdout || "");
+  process.exit(triage.status ?? 0);
+} else {
+  args = ["--tile"];
+}
+
+const result = spawnSync(process.execPath, [substrate, ...args], {
+  encoding: "utf8",
+  cwd: root,
+  env: process.env,
+});
+process.stdout.write(result.stdout || "");
+process.stderr.write(result.stderr || "");
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- Add GECKO `sensing-belt-progress` skill that wraps sonar-api `scripts/belt-progress.mjs`
- Emits `STATUS|SIGNAL|MISMATCH` tile + `--json` triage (tip lag, stall class, ETA)
- Sense-only; refuses wipe/`ENVIO_RESTART` (substrate enforces)

## Test plan
- [ ] `node skills/sensing-belt-progress/resources/sense-belt-progress.mjs --tile` (needs `SONAR_API_ROOT` or `~/Documents/GitHub/sonar-api` with belt-progress)
- [ ] `--json` emits tile then triage envelope
- [ ] Missing substrate → `blind|…` exit 3


Made with [Cursor](https://cursor.com)